### PR TITLE
Update README.md for uvx instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,25 @@ The Postgres MCP Pro Docker image will automatically remap the hostname `localho
 - MacOS/Windows: Uses `host.docker.internal` automatically
 - Linux: Uses `172.17.0.1` or the appropriate host address automatically
 
+##### If you are using `uvx`
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "uvx",
+      "args": [
+        "postgres-mcp",
+        "--access-mode=unrestricted"
+      ],
+      "env": {
+        "DATABASE_URI": "postgresql://username:password@localhost:5432/dbname"
+      }
+    }
+  }
+}
+```
+
 
 ##### If you are using `pipx`
 


### PR DESCRIPTION
I realized that the PYPI package `https://pypi.org/project/postgres-mcp/` exists(and is up tp date).
Thus config with `uvx`  actually works although not mentioned in the Readme. example:
```
"postgres": {
      "command": "uvx",
      "args": [
        "postgres-mcp",
        "--access-mode=unrestricted"
      ],
      "env": {
        "DATABASE_URI": "postgres://user:password@localhost:5432/proxy"
      }
    }
```

So here is a PR to add it to README.