### PR TITLE
Feature: JSON and CSV output formats

### DIFF
--- a/tests/unit/test_execute.py
+++ b/tests/unit/test_execute.py
@@ -1,0 +1,49 @@
+"""Tests for execute_sql function with JSON and CSV output formats."""
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from postgres_mcp.server import execute_sql
+
+
+class MockRow:
+    def __init__(self, cells):
+        self.cells = cells
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_json_output():
+    """Test execute_sql outputs valid JSON (not Python repr format)."""
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = [
+        MockRow({"id": 1, "salary": Decimal('50000.00'), "created_at": datetime(2023, 1, 1)})
+    ]
+
+    with patch('postgres_mcp.server.get_sql_driver', return_value=mock_driver):
+        result = await execute_sql("SELECT * FROM users")
+
+    # Should return valid JSON
+    parsed = json.loads(result[0].text)
+    assert parsed[0]["salary"] == 50000.0  # Decimal -> float, not repr
+    assert parsed[0]["created_at"] == "2023-01-01T00:00:00"  # ISO format
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_csv_output():
+    """Test execute_sql outputs CSV format."""
+    mock_driver = AsyncMock()
+    mock_driver.execute_query.return_value = [
+        MockRow({"id": 1, "name": "John", "salary": Decimal('50000.00')})
+    ]
+
+    with patch('postgres_mcp.server.get_sql_driver', return_value=mock_driver):
+        result = await execute_sql("SELECT * FROM users", output_format="csv")
+
+    lines = result[0].text.strip().split('\n')
+    assert len(lines) == 2  # Header + data
+    assert "id" in lines[0]
+    assert "50000.00" in lines[1]  # Decimal precision preserved


### PR DESCRIPTION
  **JSON Serialization Fix:**
  - Fixed execute_sql function to return valid JSON format instead of Python repr format (e.g., Decimal('75000.00') → 75000.0)
  - Added custom JSON serializer that properly handles PostgreSQL data types:
    - Decimal → float
    - datetime/date → ISO string format
    - timedelta → total seconds
    - bytes/binary → base64 encoding
    - UUID → string representation

  **CSV Output Format:**
  - Added new output_format parameter to execute_sql function with options: "json" (default) or "csv"
  - Implemented format_csv_response() function that converts query results to proper CSV format
  - CSV format preserves decimal precision and handles complex data types appropriately