### PR TITLE
Add percentile_cont, percentile_disc, and mode to ALLOWED_FUNCTIONS

### DIFF
--- a/src/postgres_mcp/sql/safe_sql.py
+++ b/src/postgres_mcp/sql/safe_sql.py
@@ -170,6 +170,9 @@ class SafeSqlDriver(SqlDriver):
         "trim_scale",
         "trunc",
         "width_bucket",
+        "percentile_cont",
+        "percentile_disc",
+        "mode",
         # Trigonometric functions
         "acos",
         "acosd",


### PR DESCRIPTION
adding the following aggregation functions to allowed list:
- [percentile_cont](https://www.postgresql.org/docs/9.4/functions-aggregate.html)
- [percentile_disc](https://www.postgresql.org/docs/9.4/functions-aggregate.html)
- [mode](https://wiki.postgresql.org/wiki/Aggregate_Mode)