### PR TITLE
Add CORS support for SSE transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,16 @@ For Windsurf, the format in `mcp_config.json` is slightly different:
 }
 ```
 
+For local integration with your browser using, for example, [MCP for claude.ai](https://chromewebstore.google.com/detail/jbdhaamjibfahpekpnjeikanebpdpfpb?utm_source=item-share-cb), you may need to allow certain CORS origins, such as https://claude.ai. To do this, start the server with the `--cors-origin` parameter and provide the list of domains you want to whitelist.
+
+For example, with Docker run:
+
+```bash
+docker run -p 8000:8000 \
+  -e DATABASE_URI=postgresql://username:password@localhost:5432/dbname \
+  crystaldba/postgres-mcp --access-mode=unrestricted --transport=sse --cors-origin=https://claude.ai
+```
+
 ## Postgres Extension Installation (Optional)
 
 To enable index tuning and comprehensive performance analysis you need to load the `pg_statements` and `hypopg` extensions on your database.

--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ For Windsurf, the format in `mcp_config.json` is slightly different:
 }
 ```
 
-For local integration with your browser using, for example, [MCP for claude.ai](https://chromewebstore.google.com/detail/jbdhaamjibfahpekpnjeikanebpdpfpb?utm_source=item-share-cb), you may need to allow certain CORS origins, such as https://claude.ai. To do this, start the server with the `--cors-origin` parameter and provide the list of domains you want to whitelist.
+For local integration with your browser using, for example, [MCP for claude.ai](https://chromewebstore.google.com/detail/jbdhaamjibfahpekpnjeikanebpdpfpb?utm_source=item-share-cb), you may need to allow certain CORS origins, such as https://claude.ai. To do this, start the server with the `--cors-origins` parameter and provide the list of origins you want to whitelist.
 
 For example, with Docker run:
 
 ```bash
 docker run -p 8000:8000 \
   -e DATABASE_URI=postgresql://username:password@localhost:5432/dbname \
-  crystaldba/postgres-mcp --access-mode=unrestricted --transport=sse --cors-origin=https://claude.ai
+  crystaldba/postgres-mcp --access-mode=unrestricted --transport=sse --cors-origins https://claude.ai
 ```
 
 ## Postgres Extension Installation (Optional)

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -600,7 +600,7 @@ async def main():
         starlette_app = mcp.sse_app()
 
         if args.cors_origins:
-            logger.info(f"Enabling CORS for origins: {", ".join(args.cors_origins)}")
+            logger.info(f"Enabling CORS for origins: {', '.join(args.cors_origins)}")
             starlette_app.add_middleware(
                 CORSMiddleware,
                 allow_origins=args.cors_origins,

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -12,15 +12,11 @@ from typing import Literal
 from typing import Union
 
 import mcp.types as types
-from mcp.server.fastmcp import FastMCP
-
-from starlette.middleware.cors import CORSMiddleware
-from starlette.middleware import Middleware
-
 import uvicorn
-
+from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 from pydantic import validate_call
+from starlette.middleware.cors import CORSMiddleware
 
 from postgres_mcp.index.dta_calc import DatabaseTuningAdvisor
 
@@ -602,7 +598,7 @@ async def main():
         await mcp.run_stdio_async()
     else:
         starlette_app = mcp.sse_app()
-        
+
         if args.cors_origins:
             logger.info(f"Enabling CORS for origins: {", ".join(args.cors_origins)}")
             starlette_app.add_middleware(
@@ -620,7 +616,6 @@ async def main():
         )
         server = uvicorn.Server(config)
         await server.serve()
-
 
 
 async def shutdown(sig=None):

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,0 +1,136 @@
+"""Tests for CORS support in SSE transport."""
+
+import pytest
+from starlette.middleware.cors import CORSMiddleware
+from starlette.testclient import TestClient
+
+from postgres_mcp.server import mcp
+
+
+@pytest.fixture
+def app_with_cors():
+    """Create an SSE app with CORS middleware configured."""
+    app = mcp.sse_app()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["https://claude.ai", "https://example.com"],
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+    )
+    return app
+
+
+@pytest.fixture
+def app_without_cors():
+    """Create an SSE app without CORS middleware."""
+    return mcp.sse_app()
+
+
+class TestCorsPreflightRequests:
+    """Test CORS preflight (OPTIONS) requests."""
+
+    def test_preflight_allowed_origin_returns_cors_headers(self, app_with_cors):
+        """OPTIONS preflight from allowed origin should return CORS headers."""
+        client = TestClient(app_with_cors, raise_server_exceptions=False)
+        response = client.options(
+            "/sse",
+            headers={
+                "Origin": "https://claude.ai",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "https://claude.ai"
+        assert "GET" in response.headers.get("access-control-allow-methods", "")
+
+    def test_preflight_second_allowed_origin(self, app_with_cors):
+        """OPTIONS preflight from second allowed origin should also work."""
+        client = TestClient(app_with_cors, raise_server_exceptions=False)
+        response = client.options(
+            "/sse",
+            headers={
+                "Origin": "https://example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "https://example.com"
+
+    def test_preflight_disallowed_origin_no_cors_header(self, app_with_cors):
+        """OPTIONS preflight from non-allowed origin should not return CORS header."""
+        client = TestClient(app_with_cors, raise_server_exceptions=False)
+        response = client.options(
+            "/sse",
+            headers={
+                "Origin": "https://malicious.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        # The response may be 200 or 400, but should NOT have the allow-origin header
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_preflight_messages_endpoint(self, app_with_cors):
+        """OPTIONS preflight on /messages/ endpoint should also work."""
+        client = TestClient(app_with_cors, raise_server_exceptions=False)
+        response = client.options(
+            "/messages/",
+            headers={
+                "Origin": "https://claude.ai",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "https://claude.ai"
+        assert "POST" in response.headers.get("access-control-allow-methods", "")
+
+
+class TestCorsOnActualRequests:
+    """Test CORS headers on actual (non-preflight) requests."""
+
+    def test_post_request_with_allowed_origin(self, app_with_cors):
+        """POST request from allowed origin should include CORS header in response."""
+        client = TestClient(app_with_cors, raise_server_exceptions=False)
+        # Send a POST to /messages/ - it will fail (no valid session) but CORS headers should be present
+        response = client.post(
+            "/messages/",
+            headers={"Origin": "https://claude.ai"},
+            content="test",
+        )
+        # Even if the request fails, CORS headers should be present
+        assert response.headers.get("access-control-allow-origin") == "https://claude.ai"
+
+    def test_post_request_with_disallowed_origin(self, app_with_cors):
+        """POST request from non-allowed origin should not have CORS header."""
+        client = TestClient(app_with_cors, raise_server_exceptions=False)
+        response = client.post(
+            "/messages/",
+            headers={"Origin": "https://malicious.com"},
+            content="test",
+        )
+        assert response.headers.get("access-control-allow-origin") is None
+
+
+class TestCorsDisabled:
+    """Test behavior when CORS middleware is not configured."""
+
+    def test_preflight_without_cors_middleware(self, app_without_cors):
+        """App without CORS middleware should not handle preflight specially."""
+        client = TestClient(app_without_cors, raise_server_exceptions=False)
+        response = client.options(
+            "/sse",
+            headers={
+                "Origin": "https://claude.ai",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_request_without_cors_middleware(self, app_without_cors):
+        """App without CORS middleware should not return CORS headers."""
+        client = TestClient(app_without_cors, raise_server_exceptions=False)
+        response = client.post(
+            "/messages/",
+            headers={"Origin": "https://claude.ai"},
+            content="test",
+        )
+        assert response.headers.get("access-control-allow-origin") is None


### PR DESCRIPTION
## Summary

Adds optional CORS support for the SSE transport, allowing browser-based MCP clients (like the Claude.ai Chrome extension) to connect to locally-running postgres-mcp servers.

**This PR is based on the excellent work by @pbeast in #87.** Their implementation provided the foundation - this PR adds fixes and test coverage.

### Changes from original PR #87:
- Fixed README to use correct argument name (`--cors-origins` not `--cors-origin`)
- Fixed Docker example syntax (space not `=` for argparse nargs)
- Removed unused import
- Fixed import sorting and trailing whitespace
- Added comprehensive pytest test coverage (8 tests)

### Features:
- Adds `--cors-origins` argument to whitelist allowed origins
- Uses Starlette's `CORSMiddleware` on the SSE app
- Works with multiple origins: `--cors-origins https://claude.ai https://example.com`

## Usage

```bash
postgres-mcp --transport=sse --cors-origins https://claude.ai https://example.com
```

## Test plan

- [x] CORS preflight requests return correct headers for allowed origins
- [x] CORS preflight requests reject non-allowed origins  
- [x] Actual requests include CORS headers for allowed origins
- [x] No CORS headers when middleware not configured
- [x] All 157 unit tests pass

Fixes #73

🤖 Generated with [Claude Code](https://claude.ai/claude-code)