### PR TITLE
Fix docker-entrypoint.sh to support http-streamable related parameters

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,23 +62,32 @@ if [[ -n "$DATABASE_URI" && "$DATABASE_URI" == *"postgres"*"://"*"localhost"* ]]
     fi
 fi
 
-# Check if SSE transport is specified and --sse-host is not already set
+# Check if SSE or streamable-http transport is specified and host is not already set
 has_sse=false
 has_sse_host=false
+has_streamable_http=false
+has_streamable_http_host=false
 
 for arg in "${processed_args[@]}"; do
     if [[ "$arg" == "--transport" ]]; then
-        # Check next argument for "sse"
+        # Check next argument for "sse" or "streamable-http"
         for next_arg in "${processed_args[@]}"; do
             if [[ "$next_arg" == "sse" ]]; then
                 has_sse=true
+                break
+            elif [[ "$next_arg" == "streamable-http" ]]; then
+                has_streamable_http=true
                 break
             fi
         done
     elif [[ "$arg" == "--transport=sse" ]]; then
         has_sse=true
+    elif [[ "$arg" == "--transport=streamable-http" ]]; then
+        has_streamable_http=true
     elif [[ "$arg" == "--sse-host"* ]]; then
         has_sse_host=true
+    elif [[ "$arg" == "--streamable-http-host"* ]]; then
+        has_streamable_http_host=true
     fi
 done
 
@@ -86,6 +95,12 @@ done
 if [[ "$has_sse" == true ]] && [[ "$has_sse_host" == false ]]; then
     echo "SSE transport detected, adding --sse-host=0.0.0.0" >&2
     processed_args+=("--sse-host=0.0.0.0")
+fi
+
+# Add --streamable-http-host if needed
+if [[ "$has_streamable_http" == true ]] && [[ "$has_streamable_http_host" == false ]]; then
+    echo "Streamable HTTP transport detected, adding --streamable-http-host=0.0.0.0" >&2
+    processed_args+=("--streamable-http-host=0.0.0.0")
 fi
 
 echo "----------------" >&2


### PR DESCRIPTION
The Dockerfile entrypoint was not propagating the http-streamable parameters. This Pull Request fixes that.

I am not sure if the Docker image is meant to be maintained because I see that has not been updated in a long time on your end, I created this issue https://github.com/crystaldba/postgres-mcp/issues/141