### PR TITLE
Return error message if table does not exist

### DIFF
--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -215,6 +215,22 @@ async def get_object_details(
                 """,
                 [schema_name, object_name],
             )
+
+            # If no columns found, check if table/view actually exists
+            if not col_rows:
+                exists_rows = await SafeSqlDriver.execute_param_query(
+                    sql_driver,
+                    """
+                    SELECT tablename FROM pg_tables WHERE schemaname = {} AND tablename = {}
+                    UNION
+                    SELECT viewname FROM pg_views WHERE schemaname = {} AND viewname = {}
+                    """,
+                    [schema_name, object_name, schema_name, object_name],
+                )
+
+                if not exists_rows:
+                    return format_error_response(f"{object_type.capitalize()} '{schema_name}.{object_name}' does not exist")
+
             columns = (
                 [
                     {


### PR DESCRIPTION
Previously if a describe action tried to describe a table which did not exist, it would return a successful response with 0 column, now it will verify the table exists if 0 columns exist on it.

Tested edge case with actual table with 0 columns, and it passed.