### PR TITLE
feat: Add readonly access mode for database-level read-only enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,11 @@ Replace `postgresql://...` with your [Postgres database connection URI](https://
 
 Postgres MCP Pro supports multiple *access modes* to give you control over the operations that the AI agent can perform on the database:
 - **Unrestricted Mode**: Allows full read/write access to modify data and schema. It is suitable for development environments.
-- **Restricted Mode**: Limits operations to read-only transactions and imposes constraints on resource utilization (presently only execution time). It is suitable for production environments.
+- **Restricted Mode**: Limits operations to read-only transactions and imposes constraints on resource utilization (presently only execution time). Uses pglast to parse and validate SQL before execution. It is suitable for production environments.
+- **Readonly Mode**: Enforces read-only transactions at the database level without SQL validation. This allows complex queries (nested CTEs, `PERCENTILE_CONT ... WITHIN GROUP`, complex window functions) that pglast may reject, while still preventing writes via PostgreSQL's `READ ONLY` transaction mode. Note that multi-statement queries containing `COMMIT; DROP TABLE ...` will not be caught by SQL validation — protection relies solely on the database transaction.
 
 To use restricted mode, replace `--access-mode=unrestricted` with `--access-mode=restricted` in the configuration examples above.
+To use readonly mode, replace `--access-mode=unrestricted` with `--access-mode=readonly`.
 
 
 #### Other MCP Clients
@@ -605,11 +607,15 @@ We reject any SQL that contains `commit` or `rollback` statements.
 Helpfully, the popular Postgres stored procedure languages, including PL/pgSQL and PL/Python, do not allow for `COMMIT` or `ROLLBACK` statements.
 If you have unsafe stored procedure languages enabled on your database, then our read-only protections could be circumvented.
 
-At present, Postgres MCP Pro provides two levels of protection for the database, one at either extreme of the convenience/safety spectrum.
+At present, Postgres MCP Pro provides three levels of protection for the database.
 - "Unrestricted" provides maximum flexibility.
 It is suitable for development environments where speed and flexibility are paramount, and where there is no need to protect valuable or sensitive data.
-- "Restricted" provides a balance between flexibility and safety.
+- "Restricted" provides maximum safety.
 It is suitable for production environments where the database is exposed to untrusted users, and where it is important to protect valuable or sensitive data.
+- "Readonly" provides a middle ground between Unrestricted and Restricted.
+It enforces read-only transactions at the database level (via `BEGIN TRANSACTION READ ONLY`) without pglast SQL validation.
+This allows complex queries that pglast rejects, while still preventing writes.
+However, multi-statement queries like `COMMIT; DROP TABLE` are not caught by SQL validation — protection relies solely on the database transaction.
 
 Unrestricted mode aligns with the approach of [Cursor's auto-run mode](https://docs.cursor.com/chat/tools#auto-run), where the AI agent operates with limited human oversight or approvals.
 We expect auto-run to be deployed in development environments where the consequences of mistakes are low, where databases do not contain valuable or sensitive data, and where they can be recreated or restored from backups when needed.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -14,7 +14,7 @@ startCommand:
         description: URI for accessing the database, e.g., postgres://user:password@host:port/database.
       accessMode:
         type: string
-        description: The access mode for the MCP, e.g., "restricted" or "unrestricted".
+        description: The access mode for the MCP, e.g., "restricted", "unrestricted", or "readonly".
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -28,6 +28,7 @@ from .index.index_opt_base import MAX_NUM_INDEX_TUNING_QUERIES
 from .index.llm_opt import LLMOptimizerTool
 from .index.presentation import TextPresentation
 from .sql import DbConnPool
+from .sql import ReadOnlySqlDriver
 from .sql import SafeSqlDriver
 from .sql import SqlDriver
 from .sql import check_hypopg_installation_status
@@ -51,6 +52,7 @@ class AccessMode(str, Enum):
 
     UNRESTRICTED = "unrestricted"  # Unrestricted access
     RESTRICTED = "restricted"  # Read-only with safety features
+    READONLY = "readonly"  # Read-only at DB level, no SQL validation
 
 
 # Global variables
@@ -59,13 +61,16 @@ current_access_mode = AccessMode.UNRESTRICTED
 shutdown_in_progress = False
 
 
-async def get_sql_driver() -> Union[SqlDriver, SafeSqlDriver]:
+async def get_sql_driver() -> Union[SqlDriver, SafeSqlDriver, ReadOnlySqlDriver]:
     """Get the appropriate SQL driver based on the current access mode."""
     base_driver = SqlDriver(conn=db_connection)
 
     if current_access_mode == AccessMode.RESTRICTED:
         logger.debug("Using SafeSqlDriver with restrictions (RESTRICTED mode)")
         return SafeSqlDriver(sql_driver=base_driver, timeout=30)  # 30 second timeout
+    elif current_access_mode == AccessMode.READONLY:
+        logger.debug("Using ReadOnlySqlDriver (READONLY mode)")
+        return ReadOnlySqlDriver(sql_driver=base_driver, timeout=30)  # 30 second timeout
     else:
         logger.debug("Using unrestricted SqlDriver (UNRESTRICTED mode)")
         return base_driver
@@ -563,7 +568,7 @@ async def main():
         type=str,
         choices=[mode.value for mode in AccessMode],
         default=AccessMode.UNRESTRICTED.value,
-        help="Set SQL access mode: unrestricted (unrestricted) or restricted (read-only with protections)",
+        help="Set SQL access mode: unrestricted, restricted (read-only + SQL validation), or readonly (read-only, no SQL validation)",
     )
     parser.add_argument(
         "--transport",

--- a/src/postgres_mcp/sql/__init__.py
+++ b/src/postgres_mcp/sql/__init__.py
@@ -9,6 +9,7 @@ from .extension_utils import check_postgres_version_requirement
 from .extension_utils import get_postgres_version
 from .extension_utils import reset_postgres_version_cache
 from .index import IndexDefinition
+from .readonly_sql import ReadOnlySqlDriver
 from .safe_sql import SafeSqlDriver
 from .sql_driver import DbConnPool
 from .sql_driver import SqlDriver
@@ -18,6 +19,7 @@ __all__ = [
     "ColumnCollector",
     "DbConnPool",
     "IndexDefinition",
+    "ReadOnlySqlDriver",
     "SafeSqlDriver",
     "SqlBindParams",
     "SqlDriver",

--- a/src/postgres_mcp/sql/readonly_sql.py
+++ b/src/postgres_mcp/sql/readonly_sql.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from typing import Optional
+
+from typing_extensions import LiteralString
+
+from .sql_driver import SqlDriver
+
+logger = logging.getLogger(__name__)
+
+
+class ReadOnlySqlDriver(SqlDriver):
+    """A wrapper around any SqlDriver that enforces read-only mode at the database level.
+
+    Unlike SafeSqlDriver, this driver does NOT perform pglast SQL validation.
+    Instead, it relies on PostgreSQL's READ ONLY transaction mode to prevent writes.
+    This allows complex but safe read-only queries (nested CTEs, PERCENTILE_CONT
+    WITHIN GROUP, complex window functions, etc.) that pglast may reject.
+    """
+
+    def __init__(self, sql_driver: SqlDriver, timeout: float | None = None):
+        """Initialize with an underlying SQL driver and optional timeout.
+
+        Args:
+            sql_driver: The underlying SQL driver to wrap
+            timeout: Optional timeout in seconds for query execution
+        """
+        self.sql_driver = sql_driver
+        self.timeout = timeout
+
+    async def execute_query(
+        self,
+        query: LiteralString,
+        params: list[Any] | None = None,
+        force_readonly: bool = True,  # do not use value passed in
+    ) -> Optional[list[SqlDriver.RowResult]]:  # noqa: UP007
+        """Execute a query with forced read-only mode, without SQL validation."""
+        # NOTE: Always force readonly=True in ReadOnlySqlDriver regardless of what was passed
+        if self.timeout:
+            try:
+                async with asyncio.timeout(self.timeout):
+                    return await self.sql_driver.execute_query(
+                        f"/* crystaldba */ {query}",
+                        params=params,
+                        force_readonly=True,
+                    )
+            except asyncio.TimeoutError as e:
+                logger.warning(f"Query execution timed out after {self.timeout} seconds: {query[:100]}...")
+                raise ValueError(
+                    f"Query execution timed out after {self.timeout} seconds in readonly mode. "
+                    "Consider simplifying your query or increasing the timeout."
+                ) from e
+            except Exception as e:
+                logger.error(f"Error executing query: {e}")
+                raise
+        else:
+            return await self.sql_driver.execute_query(
+                f"/* crystaldba */ {query}",
+                params=params,
+                force_readonly=True,
+            )

--- a/tests/unit/sql/test_readonly_enforcement.py
+++ b/tests/unit/sql/test_readonly_enforcement.py
@@ -6,6 +6,7 @@ import pytest
 
 from postgres_mcp.server import AccessMode
 from postgres_mcp.server import get_sql_driver
+from postgres_mcp.sql import ReadOnlySqlDriver
 from postgres_mcp.sql import SafeSqlDriver
 from postgres_mcp.sql import SqlDriver
 
@@ -64,6 +65,36 @@ async def test_force_readonly_enforcement():
     ):
         driver = await get_sql_driver()
         assert isinstance(driver, SafeSqlDriver)
+
+        # Test default behavior
+        mock_execute.reset_mock()
+        await driver.execute_query("SELECT 1")
+        assert mock_execute.call_count == 1
+        # Check that force_readonly is always True
+        assert mock_execute.call_args[1]["force_readonly"] is True
+
+        # Test explicit False (should still be True)
+        mock_execute.reset_mock()
+        await driver.execute_query("SELECT 1", force_readonly=False)
+        assert mock_execute.call_count == 1
+        # Check that force_readonly is True despite passing False
+        assert mock_execute.call_args[1]["force_readonly"] is True
+
+        # Test explicit True
+        mock_execute.reset_mock()
+        await driver.execute_query("SELECT 1", force_readonly=True)
+        assert mock_execute.call_count == 1
+        # Check that force_readonly remains True
+        assert mock_execute.call_args[1]["force_readonly"] is True
+
+    # Test READONLY mode
+    with (
+        patch("postgres_mcp.server.current_access_mode", AccessMode.READONLY),
+        patch("postgres_mcp.server.db_connection", mock_conn_pool),
+        patch.object(SqlDriver, "_execute_with_connection", mock_execute),
+    ):
+        driver = await get_sql_driver()
+        assert isinstance(driver, ReadOnlySqlDriver)
 
         # Test default behavior
         mock_execute.reset_mock()

--- a/tests/unit/sql/test_readonly_sql.py
+++ b/tests/unit/sql/test_readonly_sql.py
@@ -1,0 +1,125 @@
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from postgres_mcp.sql.readonly_sql import ReadOnlySqlDriver
+from postgres_mcp.sql.sql_driver import SqlDriver
+
+
+@pytest.fixture
+def mock_sql_driver():
+    """Create a mock base SqlDriver."""
+    driver = MagicMock(spec=SqlDriver)
+    driver.execute_query = AsyncMock(return_value=[SqlDriver.RowResult(cells={"test": "value"})])
+    return driver
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_forces_readonly(mock_sql_driver):
+    """Test that force_readonly=True is always passed, even if caller passes False."""
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=30)
+
+    # Default call
+    await readonly_driver.execute_query("SELECT 1")
+    assert mock_sql_driver.execute_query.call_args[1]["force_readonly"] is True
+
+    # Explicit False should still result in True
+    mock_sql_driver.execute_query.reset_mock()
+    await readonly_driver.execute_query("SELECT 1", force_readonly=False)
+    assert mock_sql_driver.execute_query.call_args[1]["force_readonly"] is True
+
+    # Explicit True
+    mock_sql_driver.execute_query.reset_mock()
+    await readonly_driver.execute_query("SELECT 1", force_readonly=True)
+    assert mock_sql_driver.execute_query.call_args[1]["force_readonly"] is True
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_no_validation(mock_sql_driver):
+    """Test that any SQL passes through without pglast validation (INSERT, DROP, etc.)."""
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=30)
+
+    # These would be rejected by SafeSqlDriver's pglast validation,
+    # but ReadOnlySqlDriver should pass them through (DB will reject at transaction level)
+    dangerous_queries = [
+        "INSERT INTO users (name) VALUES ('test')",
+        "DROP TABLE users",
+        "UPDATE users SET name = 'hacked'",
+        "DELETE FROM users",
+        "CREATE TABLE evil (id int)",
+    ]
+
+    for query in dangerous_queries:
+        mock_sql_driver.execute_query.reset_mock()
+        await readonly_driver.execute_query(query)
+        assert mock_sql_driver.execute_query.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_prepends_comment(mock_sql_driver):
+    """Test that /* crystaldba */ prefix is added to queries."""
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=30)
+
+    await readonly_driver.execute_query("SELECT 1")
+
+    called_query = mock_sql_driver.execute_query.call_args[0][0]
+    assert called_query == "/* crystaldba */ SELECT 1"
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_timeout(mock_sql_driver):
+    """Test that timeout raises ValueError on expiry."""
+
+    async def slow_query(*args, **kwargs):
+        await asyncio.sleep(10)
+        return [SqlDriver.RowResult(cells={"test": "value"})]
+
+    mock_sql_driver.execute_query = slow_query
+
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=0.01)
+
+    with pytest.raises(ValueError, match=r"timed out.*readonly mode"):
+        await readonly_driver.execute_query("SELECT pg_sleep(10)")
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_no_timeout(mock_sql_driver):
+    """Test that queries work without timeout when timeout is None."""
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=None)
+
+    result = await readonly_driver.execute_query("SELECT 1")
+    assert result == [SqlDriver.RowResult(cells={"test": "value"})]
+    assert mock_sql_driver.execute_query.call_args[1]["force_readonly"] is True
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_passes_params(mock_sql_driver):
+    """Test that query parameters are forwarded correctly."""
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=30)
+
+    params = ["param1", 42]
+    await readonly_driver.execute_query("SELECT * FROM t WHERE a = $1 AND b = $2", params=params)
+
+    call_kwargs = mock_sql_driver.execute_query.call_args[1]
+    assert call_kwargs["params"] == params
+    assert call_kwargs["force_readonly"] is True
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_forwards_exceptions(mock_sql_driver):
+    """Test that exceptions from the underlying driver propagate."""
+    mock_sql_driver.execute_query = AsyncMock(side_effect=RuntimeError("connection lost"))
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=30)
+    with pytest.raises(RuntimeError, match="connection lost"):
+        await readonly_driver.execute_query("SELECT 1")
+
+
+@pytest.mark.asyncio
+async def test_readonly_driver_none_result(mock_sql_driver):
+    """Test that None result (DDL/no-result queries) is forwarded."""
+    mock_sql_driver.execute_query = AsyncMock(return_value=None)
+    readonly_driver = ReadOnlySqlDriver(sql_driver=mock_sql_driver, timeout=30)
+    result = await readonly_driver.execute_query("VACUUM")
+    assert result is None

--- a/tests/unit/test_access_mode.py
+++ b/tests/unit/test_access_mode.py
@@ -7,6 +7,7 @@ import pytest
 
 from postgres_mcp.server import AccessMode
 from postgres_mcp.server import get_sql_driver
+from postgres_mcp.sql.readonly_sql import ReadOnlySqlDriver
 from postgres_mcp.sql.safe_sql import SafeSqlDriver
 from postgres_mcp.sql.sql_driver import DbConnPool
 from postgres_mcp.sql.sql_driver import SqlDriver
@@ -25,6 +26,7 @@ def mock_db_connection():
     [
         (AccessMode.UNRESTRICTED, SqlDriver),
         (AccessMode.RESTRICTED, SafeSqlDriver),
+        (AccessMode.READONLY, ReadOnlySqlDriver),
     ],
 )
 @pytest.mark.asyncio
@@ -40,6 +42,11 @@ async def test_get_sql_driver_returns_correct_driver(access_mode, expected_drive
         # When in RESTRICTED mode, verify timeout is set
         if access_mode == AccessMode.RESTRICTED:
             assert isinstance(driver, SafeSqlDriver)
+            assert driver.timeout == 30
+
+        # When in READONLY mode, verify timeout is set
+        if access_mode == AccessMode.READONLY:
+            assert isinstance(driver, ReadOnlySqlDriver)
             assert driver.timeout == 30
 
 
@@ -110,5 +117,47 @@ async def test_command_line_parsing():
 
     finally:
         # Restore original values
+        sys.argv = original_argv
+        asyncio.run = original_run
+
+
+@pytest.mark.asyncio
+async def test_command_line_parsing_readonly():
+    """Test that --access-mode=readonly correctly sets the access mode."""
+    import sys
+
+    from postgres_mcp.server import main
+
+    # Mock sys.argv and asyncio.run
+    original_argv = sys.argv
+    original_run = asyncio.run
+
+    try:
+        sys.argv = [
+            "postgres_mcp",
+            "postgresql://user:password@localhost/db",
+            "--access-mode=readonly",
+        ]
+        asyncio.run = AsyncMock()
+
+        with (
+            patch("postgres_mcp.server.current_access_mode", AccessMode.UNRESTRICTED),
+            patch("postgres_mcp.server.db_connection.pool_connect", AsyncMock()),
+            patch("postgres_mcp.server.mcp.run_stdio_async", AsyncMock()),
+            patch("postgres_mcp.server.shutdown", AsyncMock()),
+        ):
+            import postgres_mcp.server
+
+            postgres_mcp.server.current_access_mode = AccessMode.UNRESTRICTED
+
+            try:
+                await main()
+            except Exception:
+                pass
+
+            # Verify the mode was changed to READONLY
+            assert postgres_mcp.server.current_access_mode == AccessMode.READONLY
+
+    finally:
         sys.argv = original_argv
         asyncio.run = original_run


### PR DESCRIPTION
## Summary

Add a third access mode `--access-mode=readonly` that enforces read-only
transactions at the PostgreSQL level without pglast SQL validation.
This fills the gap between `unrestricted` (no protection) and `restricted`
(pglast rejects complex queries).

## Problem

The `restricted` mode uses pglast to parse SQL into an AST and validate
statements against whitelists. While this catches writes at the application
layer, it also **rejects legitimate read-only queries** that pglast cannot
parse:

- `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration)` — pglast parse error
- Nested CTEs with complex joins — rejected as unsupported node types
- Window functions with advanced framing — pglast validation failure
- Extension-specific functions (`pg_trgm`, `postgis`, etc.) — not in the allowed function whitelist

Users running analytical workloads are forced to switch to `unrestricted`
mode, losing all write protection.

## Solution

### Architecture: Driver selection

The server selects a driver based on `--access-mode` CLI argument:

```mermaid
flowchart TD
    CLI["--access-mode=?"] --> U{unrestricted}
    CLI --> RO{readonly}
    CLI --> R{restricted}

    U --> SD["SqlDriver\n(no wrapper)"]
    RO --> ROSD["ReadOnlySqlDriver\n(decorator over SqlDriver)"]
    R --> SSD["SafeSqlDriver\n(decorator over SqlDriver)"]

    SD --> EQ["execute_query()\nforce_readonly=False"]
    ROSD --> EQ2["execute_query()\nforce_readonly=True ← forced\n+ /* crystaldba */ prefix\n+ 30s timeout"]
    SSD --> VAL["_validate(query)\npglast AST parsing"]
    VAL -->|pass| EQ3["execute_query()\nforce_readonly=True ← forced\n+ /* crystaldba */ prefix\n+ 30s timeout"]
    VAL -->|fail| ERR["Reject query\n(ValueError)"]

    EQ --> PG[(PostgreSQL)]
    EQ2 --> PG
    EQ3 --> PG

    style ROSD fill:#2d6a4f,stroke:#1b4332,color:#fff
    style RO fill:#2d6a4f,stroke:#1b4332,color:#fff
```

### Architecture: ReadOnlySqlDriver decorator pattern

```mermaid
flowchart TD
    CALLER["MCP Tool calls execute_query()"] --> ROSD

    subgraph ROSD["ReadOnlySqlDriver"]
        A["Ignore caller's force_readonly value"] --> B["Prepend /* crystaldba */ comment"]
        B --> C["Wrap in asyncio.timeout(30s)"]
        C --> D["Call self.sql_driver.execute_query(\n  query='/* crystaldba */ ...',\n  params=params,\n  force_readonly=True\n)"]
    end

    D --> EXEC

    subgraph EXEC["SqlDriver._execute_with_connection"]
        E["BEGIN TRANSACTION READ ONLY"] --> F["Execute user's query"]
        F --> G{Success?}
        G -->|Yes| H["ROLLBACK"]
        G -->|No| I["connection.rollback()"]
        H --> J["Return results"]
        I --> K["Raise exception"]
    end

    J --> RESULT["MCP Tool Response\n(query results)"]
    K --> ERROR["MCP Tool Response\n(error message)"]

    style ROSD fill:#2d6a4f,stroke:#1b4332,color:#fff
    style EXEC fill:#1b4332,stroke:#081c15,color:#fff
```

### Architecture: Query flow in readonly mode (sequence)

```mermaid
sequenceDiagram
    participant Tool as MCP Tool
    participant RO as ReadOnlySqlDriver
    participant SD as SqlDriver
    participant PG as PostgreSQL

    Tool->>RO: execute_query(sql, params, force_readonly=False)
    Note over RO: Ignores force_readonly=False
    Note over RO: Prepends /* crystaldba */
    Note over RO: Starts asyncio.timeout(30s)

    RO->>SD: execute_query("/* crystaldba */ " + sql, params, force_readonly=True)
    SD->>PG: BEGIN TRANSACTION READ ONLY
    PG-->>SD: OK
    SD->>PG: /* crystaldba */ SELECT ...

    alt Query succeeds
        PG-->>SD: rows
        SD->>PG: ROLLBACK
        SD-->>RO: List[RowResult]
        RO-->>Tool: List[RowResult]
    else Write attempt (INSERT, UPDATE, DROP...)
        PG-->>SD: ERROR: cannot execute INSERT in a read-only transaction
        SD->>PG: ROLLBACK
        SD-->>RO: raises Exception
        RO-->>Tool: raises Exception
    else Timeout (>30s)
        Note over RO: asyncio.TimeoutError
        RO-->>Tool: ValueError("Query execution timed out after 30 seconds")
    end
```

### Architecture: Protection layers comparison

```mermaid
graph LR
    subgraph unrestricted["unrestricted mode"]
        U1["SQL query"] --> U2["SqlDriver"] --> U3[(PostgreSQL)]
    end

    subgraph readonly["readonly mode"]
        R1["SQL query"] --> R2["ReadOnlySqlDriver\n(timeout + prefix)"] --> R3["SqlDriver\nforce_readonly=True"] --> R4[("PostgreSQL\nREAD ONLY tx")]
    end

    subgraph restricted["restricted mode"]
        S1["SQL query"] --> S2["SafeSqlDriver\npglast validation"] --> S3["SqlDriver\nforce_readonly=True"] --> S4[("PostgreSQL\nREAD ONLY tx")]
    end

    style unrestricted fill:#d4380d,stroke:#a8071a,color:#fff
    style readonly fill:#2d6a4f,stroke:#1b4332,color:#fff
    style restricted fill:#0050b3,stroke:#003a8c,color:#fff
```

### Mode comparison

| | `unrestricted` | `readonly` | `restricted` |
|---|---|---|---|
| **SQL validation** | none | none | pglast AST check |
| **DB enforcement** | none | `READ ONLY` transaction | `READ ONLY` transaction |
| **Complex queries** | all allowed | all allowed | limited by pglast |
| **Timeout** | none | 30 seconds | 30 seconds |
| **Query prefix** | none | `/* crystaldba */` | `/* crystaldba */` |
| **Protection level** | none | database-level | dual-layer (app + DB) |
| **Best for** | development | analytics / complex queries | production |

## Security trade-off

```mermaid
flowchart LR
    subgraph restricted_mode["restricted mode (dual-layer)"]
        direction TB
        L1["Layer 1: pglast\nAST validation"] --> L2["Layer 2: PostgreSQL\nREAD ONLY transaction"]
    end

    subgraph readonly_mode["readonly mode (single-layer)"]
        direction TB
        L3["No SQL validation"] --> L4["PostgreSQL\nREAD ONLY transaction"]
    end

    ATK["Multi-statement:\nCOMMIT; DROP TABLE users"]

    ATK -->|blocked by pglast| restricted_mode
    ATK -->|not parsed, but\nDROP fails in\nREAD ONLY tx| readonly_mode

    style restricted_mode fill:#0050b3,stroke:#003a8c,color:#fff
    style readonly_mode fill:#2d6a4f,stroke:#1b4332,color:#fff
```

Readonly mode does **not** validate SQL syntax. Multi-statement payloads
like `COMMIT; DROP TABLE users` are not caught at the application layer.
PostgreSQL's read-only transaction prevents the write from executing,
but this is single-layer protection vs. the dual-layer approach of
`restricted` mode.

**This trade-off is intentional:** pglast's false rejections of valid
analytical queries cause more real-world friction than the multi-statement
attack vector, which is mitigated by the database transaction boundary.

## Usage

```bash
# Start server in readonly mode
postgres-mcp "postgresql://user:pass@host/db" --access-mode=readonly

# Start server in restricted mode (strictest)
postgres-mcp "postgresql://user:pass@host/db" --access-mode=restricted

# Start server in unrestricted mode (default)
postgres-mcp "postgresql://user:pass@host/db" --access-mode=unrestricted
```

## Implementation details

### `ReadOnlySqlDriver` class (`src/postgres_mcp/sql/readonly_sql.py`)

- **Pattern:** Decorator over `SqlDriver`
- **Constructor:** `ReadOnlySqlDriver(sql_driver: SqlDriver, timeout: float | None = None)`
- **Key behavior:** `execute_query()` always passes `force_readonly=True` to the underlying driver, regardless of the caller's value
- **Timeout:** Wraps execution in `asyncio.timeout(self.timeout)`, raises `ValueError` on expiry
- **Query tagging:** Prepends `/* crystaldba */` comment for identification in `pg_stat_activity` and logs
- **No SQL validation:** Unlike `SafeSqlDriver`, does not call `_validate()` / pglast

### `get_sql_driver()` dispatch (`src/postgres_mcp/server.py`)

```python
async def get_sql_driver():
    base_driver = SqlDriver(conn=db_connection)
    if current_access_mode == AccessMode.RESTRICTED:
        return SafeSqlDriver(sql_driver=base_driver, timeout=30)
    elif current_access_mode == AccessMode.READONLY:
        return ReadOnlySqlDriver(sql_driver=base_driver, timeout=30)
    else:
        return base_driver
```

### Transaction enforcement (`src/postgres_mcp/sql/sql_driver.py`)

When `force_readonly=True`, `_execute_with_connection()` wraps every query:

```sql
BEGIN TRANSACTION READ ONLY   -- PostgreSQL enforces no writes
/* crystaldba */ <query>      -- user's query runs here
ROLLBACK                      -- transaction closed (no state change)
```

PostgreSQL rejects any `INSERT`, `UPDATE`, `DELETE`, `DROP`, `CREATE`,
`TRUNCATE`, or other write operation inside a `READ ONLY` transaction with:
```
ERROR: cannot execute <STATEMENT> in a read-only transaction
```

## Files changed

| File | Change |
|---|---|
| `src/postgres_mcp/sql/readonly_sql.py` | New `ReadOnlySqlDriver` class (decorator, timeout, force_readonly) |
| `src/postgres_mcp/server.py` | `AccessMode.READONLY` enum value, `get_sql_driver()` branch, CLI `--access-mode=readonly` |
| `src/postgres_mcp/sql/__init__.py` | Export `ReadOnlySqlDriver` |
| `smithery.yaml` | Add `readonly` to access mode config |
| `README.md` | Update "Protected SQL Execution" docs (two → three levels) |
| `tests/unit/sql/test_readonly_sql.py` | 8 unit tests for ReadOnlySqlDriver |
| `tests/unit/sql/test_readonly_enforcement.py` | 3 parameterized tests — force_readonly enforcement across all access modes |
| `tests/unit/test_access_mode.py` | Driver selection + CLI parsing for readonly |

## Test coverage

- **`test_readonly_sql.py`** (8 tests): force_readonly override, no SQL validation,
  `/* crystaldba */` prefix, timeout → ValueError, parameter forwarding,
  exception propagation, None result handling
- **`test_readonly_enforcement.py`** (3 parameterized tests): verifies force_readonly
  behavior per access mode (unrestricted respects caller, readonly/restricted force True)
- **`test_access_mode.py`**: get_sql_driver() returns correct type per mode,
  timeout=30 for restricted/readonly, CLI `--access-mode` parsing