### PR TITLE
fix(ci): use DOCKERHUB_USERNAME secret instead of hardcoded registry namespace

### DIFF
--- a/.github/workflows/docker-build-dockerhub.yml
+++ b/.github/workflows/docker-build-dockerhub.yml
@@ -60,7 +60,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
-          images: crystaldba/postgres-mcp
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/postgres-mcp
           tags: |
             type=raw,value=${{ needs.prepare.outputs.version }}
             type=raw,value=latest
@@ -84,5 +84,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-          cache-from: type=registry,ref=crystaldba/postgres-mcp:buildcache
-          cache-to: type=registry,ref=crystaldba/postgres-mcp:buildcache,mode=max
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/postgres-mcp:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/postgres-mcp:buildcache,mode=max


### PR DESCRIPTION
## Summary

- The DockerHub workflow had `crystaldba/postgres-mcp` hardcoded as the image name and cache registry references
- This caused Docker builds to fail on forks, since the forked repo's DockerHub credentials don't have push access to `crystaldba/postgres-mcp`
- Replaced all hardcoded `crystaldba` references with `${{ secrets.DOCKERHUB_USERNAME }}` so each fork can configure its own DockerHub namespace