### PR TITLE
fix(security): add SQL injection prevention to ExplainPlanTool

### DIFF
--- a/src/postgres_mcp/explain/explain_plan.py
+++ b/src/postgres_mcp/explain/explain_plan.py
@@ -7,6 +7,10 @@ import re
 from typing import TYPE_CHECKING
 from typing import Any
 
+import pglast
+from pglast.ast import RawStmt
+from pglast.ast import SelectStmt
+
 from ..artifacts import ErrorResult
 from ..artifacts import ExplainPlanArtifact
 from ..sql import IndexDefinition
@@ -65,6 +69,11 @@ class ExplainPlanTool:
         Returns:
             ExplainPlanArtifact or ErrorResult
         """
+        # Validate input to prevent SQL injection via f-string concatenation
+        validation_error = self._validate_explain_input(sql_query, analyze=do_analyze)
+        if validation_error:
+            return ErrorResult(validation_error)
+
         modified_sql_query, use_generic_plan = await self.replace_query_parameters_if_needed(sql_query)
         return await self._run_explain_query(modified_sql_query, analyze=do_analyze, generic_plan=use_generic_plan)
 
@@ -94,6 +103,11 @@ class ExplainPlanTool:
             ExplainPlanArtifact or ErrorResult
         """
         try:
+            # Validate input SQL to prevent injection
+            validation_error = self._validate_explain_input(sql_query)
+            if validation_error:
+                return ErrorResult(validation_error)
+
             # Validate index definitions format
             if not isinstance(hypothetical_indexes, list):
                 return ErrorResult(f"Expected list of index definitions, got {type(hypothetical_indexes)}")
@@ -141,6 +155,44 @@ class ExplainPlanTool:
         except Exception as e:
             logger.error(f"Error in explain_with_hypothetical_indexes: {e}", exc_info=True)
             return ErrorResult(f"Error generating explain plan with hypothetical indexes: {e}")
+
+    @staticmethod
+    def _validate_explain_input(sql_query: str, analyze: bool = False) -> str | None:
+        """Validate that the SQL input for EXPLAIN is a single, safe statement.
+
+        Parses the input with pglast to prevent SQL injection via the f-string
+        concatenation used to build EXPLAIN queries. This ensures the
+        readOnlyHint=True annotation on explain_query is honored regardless
+        of the server access mode.
+
+        Args:
+            sql_query: The SQL query to validate
+            analyze: Whether EXPLAIN ANALYZE will be used (restricts to SELECT)
+
+        Returns:
+            None if valid, or an error message string if invalid
+        """
+        if not sql_query or not sql_query.strip():
+            return "SQL query cannot be empty"
+
+        try:
+            parsed = pglast.parse_sql(sql_query)
+        except pglast.parser.ParseError as e:
+            return f"Invalid SQL syntax: {e}"
+
+        # Reject multi-statement input to prevent injection via semicolons
+        if len(parsed) != 1:
+            return f"EXPLAIN input must be a single SQL statement, got {len(parsed)} statements"
+
+        # When EXPLAIN ANALYZE is used, the query is actually executed.
+        # Restrict to SELECT statements to prevent data modification.
+        if analyze:
+            stmt = parsed[0]
+            inner = stmt.stmt if isinstance(stmt, RawStmt) else stmt
+            if not isinstance(inner, SelectStmt):
+                return "EXPLAIN ANALYZE is only supported for SELECT queries to prevent unintended data modification"
+
+        return None
 
     def _has_bind_variables(self, query: str) -> bool:
         """Check if a query contains bind variables ($1, $2, etc)."""
@@ -201,6 +253,11 @@ class ExplainPlanTool:
             The explain plan as a dictionary
         """
         try:
+            # Validate input SQL to prevent injection via f-string concatenation
+            validation_error = self._validate_explain_input(query_text)
+            if validation_error:
+                raise ValueError(validation_error)
+
             # Create the indexes query
             create_indexes_query = "SELECT hypopg_reset();"
             if len(indexes) > 0:

--- a/tests/unit/explain/test_explain_input_validation.py
+++ b/tests/unit/explain/test_explain_input_validation.py
@@ -1,0 +1,173 @@
+"""Tests for SQL injection prevention in ExplainPlanTool._validate_explain_input.
+
+These tests verify that the EXPLAIN tool validates its input SQL to prevent
+SQL injection via the f-string concatenation used to build EXPLAIN queries.
+This ensures the readOnlyHint=True annotation on explain_query is honored
+regardless of the server access mode.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from postgres_mcp.artifacts import ErrorResult
+from postgres_mcp.explain import ExplainPlanTool
+
+
+@pytest_asyncio.fixture
+async def mock_sql_driver():
+    """Create a mock SQL driver for testing."""
+    driver = MagicMock()
+    driver.execute_query = AsyncMock()
+    return driver
+
+
+# ============================================================================
+# _validate_explain_input unit tests
+# ============================================================================
+
+
+class TestValidateExplainInput:
+    """Tests for the _validate_explain_input static method."""
+
+    def test_valid_select(self):
+        """Valid SELECT queries should pass validation."""
+        assert ExplainPlanTool._validate_explain_input("SELECT * FROM users") is None
+        assert ExplainPlanTool._validate_explain_input("SELECT id, name FROM users WHERE age > 18") is None
+        assert ExplainPlanTool._validate_explain_input("SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id") is None
+
+    def test_valid_select_with_cte(self):
+        """SELECT with CTE (WITH clause) should pass."""
+        assert ExplainPlanTool._validate_explain_input("WITH active AS (SELECT * FROM users WHERE active) SELECT * FROM active") is None
+
+    def test_valid_select_with_subquery(self):
+        """SELECT with subquery should pass."""
+        assert ExplainPlanTool._validate_explain_input("SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)") is None
+
+    def test_valid_insert_without_analyze(self):
+        """INSERT should pass validation when analyze=False (EXPLAIN without ANALYZE is safe)."""
+        assert ExplainPlanTool._validate_explain_input("INSERT INTO users (name) VALUES ('test')", analyze=False) is None
+
+    def test_valid_update_without_analyze(self):
+        """UPDATE should pass validation when analyze=False."""
+        assert ExplainPlanTool._validate_explain_input("UPDATE users SET name = 'test' WHERE id = 1", analyze=False) is None
+
+    def test_valid_delete_without_analyze(self):
+        """DELETE should pass validation when analyze=False."""
+        assert ExplainPlanTool._validate_explain_input("DELETE FROM users WHERE id = 1", analyze=False) is None
+
+    def test_reject_multi_statement_injection(self):
+        """Multi-statement input should be rejected (prevents SQL injection)."""
+        result = ExplainPlanTool._validate_explain_input("SELECT 1; DROP TABLE users")
+        assert result is not None
+        assert "single SQL statement" in result
+
+    def test_reject_multi_statement_with_comment(self):
+        """Multi-statement with comment-based injection should be rejected."""
+        result = ExplainPlanTool._validate_explain_input("SELECT 1; DROP TABLE users; --")
+        assert result is not None
+        assert "single SQL statement" in result
+
+    def test_reject_empty_query(self):
+        """Empty queries should be rejected."""
+        assert ExplainPlanTool._validate_explain_input("") is not None
+        assert ExplainPlanTool._validate_explain_input("   ") is not None
+
+    def test_reject_invalid_sql(self):
+        """Invalid SQL syntax should be rejected."""
+        result = ExplainPlanTool._validate_explain_input("NOT VALID SQL AT ALL")
+        assert result is not None
+        assert "Invalid SQL syntax" in result
+
+    def test_analyze_rejects_delete(self):
+        """EXPLAIN ANALYZE should reject DELETE to prevent data modification."""
+        result = ExplainPlanTool._validate_explain_input("DELETE FROM users WHERE 1=1", analyze=True)
+        assert result is not None
+        assert "SELECT" in result
+
+    def test_analyze_rejects_update(self):
+        """EXPLAIN ANALYZE should reject UPDATE to prevent data modification."""
+        result = ExplainPlanTool._validate_explain_input("UPDATE users SET name = 'hacked'", analyze=True)
+        assert result is not None
+        assert "SELECT" in result
+
+    def test_analyze_rejects_insert(self):
+        """EXPLAIN ANALYZE should reject INSERT to prevent data modification."""
+        result = ExplainPlanTool._validate_explain_input("INSERT INTO users (name) VALUES ('test')", analyze=True)
+        assert result is not None
+        assert "SELECT" in result
+
+    def test_analyze_allows_select(self):
+        """EXPLAIN ANALYZE should allow SELECT queries."""
+        assert ExplainPlanTool._validate_explain_input("SELECT * FROM users", analyze=True) is None
+
+    def test_reject_drop_table(self):
+        """DDL statements should be rejected as multi-statement or invalid."""
+        # DROP TABLE alone is a single statement but not a valid EXPLAIN target in pglast
+        result = ExplainPlanTool._validate_explain_input("SELECT 1; DROP TABLE users")
+        assert result is not None
+
+    def test_reject_copy_injection(self):
+        """COPY-based data exfiltration should be rejected."""
+        result = ExplainPlanTool._validate_explain_input("SELECT 1; COPY (SELECT * FROM pg_shadow) TO '/tmp/pwned.csv'")
+        assert result is not None
+
+    def test_valid_select_with_bind_params(self):
+        """Queries with bind parameters ($1, $2) should pass validation."""
+        assert ExplainPlanTool._validate_explain_input("SELECT * FROM users WHERE id = $1") is None
+        assert ExplainPlanTool._validate_explain_input("SELECT * FROM users WHERE id = $1 AND name = $2") is None
+
+
+# ============================================================================
+# Integration tests: explain method blocks injection
+# ============================================================================
+
+
+class TestExplainBlocksInjection:
+    """Tests that the explain() method blocks SQL injection attempts."""
+
+    @pytest.mark.asyncio
+    async def test_explain_blocks_multi_statement(self, mock_sql_driver):
+        """explain() should return ErrorResult for multi-statement injection."""
+        tool = ExplainPlanTool(sql_driver=mock_sql_driver)
+        result = await tool.explain("SELECT 1; DROP TABLE users")
+        assert isinstance(result, ErrorResult)
+        # Verify the query was never sent to the database
+        mock_sql_driver.execute_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explain_analyze_blocks_delete(self, mock_sql_driver):
+        """explain_analyze() should block DELETE statements."""
+        tool = ExplainPlanTool(sql_driver=mock_sql_driver)
+        result = await tool.explain_analyze("DELETE FROM users WHERE 1=1")
+        assert isinstance(result, ErrorResult)
+        mock_sql_driver.execute_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explain_analyze_blocks_update(self, mock_sql_driver):
+        """explain_analyze() should block UPDATE statements."""
+        tool = ExplainPlanTool(sql_driver=mock_sql_driver)
+        result = await tool.explain_analyze("UPDATE users SET admin = true")
+        assert isinstance(result, ErrorResult)
+        mock_sql_driver.execute_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explain_blocks_empty_input(self, mock_sql_driver):
+        """explain() should return ErrorResult for empty input."""
+        tool = ExplainPlanTool(sql_driver=mock_sql_driver)
+        result = await tool.explain("")
+        assert isinstance(result, ErrorResult)
+        mock_sql_driver.execute_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explain_with_hypothetical_indexes_blocks_injection(self, mock_sql_driver):
+        """explain_with_hypothetical_indexes() should block SQL injection."""
+        tool = ExplainPlanTool(sql_driver=mock_sql_driver)
+        result = await tool.explain_with_hypothetical_indexes(
+            "SELECT 1; DROP TABLE users",
+            [{"table": "users", "columns": ["email"]}],
+        )
+        assert isinstance(result, ErrorResult)
+        mock_sql_driver.execute_query.assert_not_awaited()


### PR DESCRIPTION
## Summary

The `explain_query` tool is annotated with `readOnlyHint=True`, but in UNRESTRICTED mode (default), user-supplied SQL is concatenated via f-string into EXPLAIN queries without validation. This allows:

1. **Multi-statement SQL injection** — e.g., `SELECT 1; DROP TABLE users` passes through `f"EXPLAIN (FORMAT JSON) {sql_input}"` and reaches `cursor.execute()` which supports multi-statement execution via `cursor.nextset()`
2. 2. **EXPLAIN ANALYZE DML execution** — `EXPLAIN ANALYZE DELETE FROM users` actually executes the DELETE, but the tool doesn't restrict this
### What this PR does

Adds `_validate_explain_input()` static method using `pglast` (already a project dependency) to:
- Parse input SQL and reject multi-statement injection attempts
- - Restrict EXPLAIN ANALYZE to SELECT-only (since it executes the query)
- - Validate syntax before f-string concatenation
Integrates validation into `explain()`, `explain_with_hypothetical_indexes()`, and `generate_explain_plan_with_hypothetical_indexes()`.

### What the codebase already gets right

- `SafeSqlDriver` provides excellent pglast-based validation in RESTRICTED mode
- - `psycopg.sql.Literal()` is used correctly for `IndexDefinition` (not exploitable)
- - Read-only transaction enforcement in RESTRICTED mode is solid
This fix extends the same validation approach to UNRESTRICTED mode for the EXPLAIN tool specifically.

### Files changed

- `src/postgres_mcp/explain/explain_plan.py` — adds `_validate_explain_input()` and integrates it (57 additions, 0 deletions)
- - `tests/unit/explain/test_explain_input_validation.py` — 22 test cases (17 unit + 5 integration)
### Test coverage

- Valid queries (SELECT, JOIN, CTE, subquery, INSERT/UPDATE/DELETE without ANALYZE, bind params)
- - Multi-statement injection rejection (semicolons, comments, COPY exfiltration)
- - Empty/invalid input handling
- - EXPLAIN ANALYZE DML restrictions (blocks DELETE, UPDATE, INSERT; allows SELECT)
- - Integration tests verifying `explain()`, `explain_analyze()`, and `explain_with_hypothetical_indexes()` block injection and never send malicious SQL to the database