### PR TITLE
Add AWS RDS IAM authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,43 @@ Postgres MCP Pro supports multiple *access modes* to give you control over the o
 To use restricted mode, replace `--access-mode=unrestricted` with `--access-mode=restricted` in the configuration examples above.
 
 
+##### AWS RDS IAM Authentication
+
+For AWS RDS databases with IAM database authentication enabled, pass `--auth-type=rds-iam`. The server generates a fresh IAM auth token on every new physical connection, so the 15-minute token TTL is invisible to callers — no wrapper scripts, no server restarts when the token expires.
+
+Requirements on the RDS side: IAM database authentication enabled on the cluster, and the DB user created with `GRANT rds_iam TO <username>`. The IAM principal running the MCP server (or the profile you pass) needs `rds-db:connect` on `arn:aws:rds-db:<region>:<account>:dbuser:<resource-id>/<username>`.
+
+The `DATABASE_URI` for IAM mode must *not* contain a password — any password in the URI is discarded:
+
+```json
+{
+  "mcpServers": {
+    "postgres-dev": {
+      "command": "uvx",
+      "args": [
+        "postgres-mcp",
+        "--access-mode=unrestricted",
+        "--auth-type=rds-iam",
+        "--aws-region=us-west-2",
+        "--aws-profile=DeveloperRDS-dev"
+      ],
+      "env": {
+        "DATABASE_URI": "postgresql://alma_developer@alma-rds-dev.cjosqcacaey8.us-west-2.rds.amazonaws.com:5432/alma?sslmode=require"
+      }
+    }
+  }
+}
+```
+
+| Flag | Env fallback | Notes |
+| --- | --- | --- |
+| `--auth-type` | — | `password` (default) or `rds-iam` |
+| `--aws-region` | `AWS_REGION`, `AWS_DEFAULT_REGION` | Required for `rds-iam` |
+| `--aws-profile` | `AWS_PROFILE` | Optional; omit to use the default credential chain |
+
+`sslmode=require` is applied by default for IAM connections since RDS rejects plaintext IAM auth.
+
+
 #### Other MCP Clients
 
 Many MCP clients have similar configuration files to Claude Desktop, and you can adapt the examples above to work with the client of your choice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ dependencies = [
     "humanize>=4.15.0",
     "pglast==7.11",
     "attrs>=25.4.0",
-    "psycopg-pool>=3.3.0",
+    "psycopg-pool>=3.3.0,<4",
     "instructor>=1.14.4",
+    "boto3>=1.34.0",
 ]
 license = "mit"
 license-files = ["LICENSE"]

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -32,6 +32,7 @@ from .sql import SafeSqlDriver
 from .sql import SqlDriver
 from .sql import check_hypopg_installation_status
 from .sql import obfuscate_password
+from .sql import parse_database_uri_for_iam
 from .top_queries import TopQueriesCalc
 
 # Initialize FastMCP with default settings
@@ -51,6 +52,13 @@ class AccessMode(str, Enum):
 
     UNRESTRICTED = "unrestricted"  # Unrestricted access
     RESTRICTED = "restricted"  # Read-only with safety features
+
+
+class AuthType(str, Enum):
+    """Database authentication methods."""
+
+    PASSWORD = "password"  # Static password embedded in DATABASE_URI
+    RDS_IAM = "rds-iam"  # AWS RDS IAM auth with per-connection token refresh
 
 
 # Global variables
@@ -566,6 +574,29 @@ async def main():
         help="Set SQL access mode: unrestricted (unrestricted) or restricted (read-only with protections)",
     )
     parser.add_argument(
+        "--auth-type",
+        type=str,
+        choices=[t.value for t in AuthType],
+        default=AuthType.PASSWORD.value,
+        help=(
+            "Authentication method. 'password' (default) uses the password embedded in "
+            "DATABASE_URI. 'rds-iam' generates a fresh RDS IAM token for every new "
+            "connection — required for AWS RDS with IAM auth enabled."
+        ),
+    )
+    parser.add_argument(
+        "--aws-region",
+        type=str,
+        default=None,
+        help="AWS region for RDS IAM auth (falls back to AWS_REGION / AWS_DEFAULT_REGION).",
+    )
+    parser.add_argument(
+        "--aws-profile",
+        type=str,
+        default=None,
+        help="AWS profile for RDS IAM auth (falls back to AWS_PROFILE).",
+    )
+    parser.add_argument(
         "--transport",
         type=str,
         choices=["stdio", "sse", "streamable-http"],
@@ -633,9 +664,31 @@ async def main():
             "Error: No database URL provided. Please specify via 'DATABASE_URI' environment variable or command-line argument.",
         )
 
+    # Build optional RDS IAM config. When set, the pool regenerates a fresh
+    # auth token on every new physical connection, making 15-min token expiry
+    # invisible to the caller.
+    iam_config = None
+    if args.auth_type == AuthType.RDS_IAM.value:
+        region = args.aws_region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        if not region:
+            raise ValueError(
+                "RDS IAM auth requires an AWS region. Pass --aws-region or set AWS_REGION / AWS_DEFAULT_REGION.",
+            )
+        profile = args.aws_profile or os.environ.get("AWS_PROFILE")
+        iam_config = parse_database_uri_for_iam(database_url, region=region, aws_profile=profile)
+        logger.info(
+            "RDS IAM auth enabled for %s@%s:%d/%s (region=%s, profile=%s)",
+            iam_config.user,
+            iam_config.host,
+            iam_config.port,
+            iam_config.dbname,
+            iam_config.region,
+            iam_config.aws_profile or "<default>",
+        )
+
     # Initialize database connection pool
     try:
-        await db_connection.pool_connect(database_url)
+        await db_connection.pool_connect(database_url, iam_config=iam_config)
         logger.info("Successfully connected to database and initialized connection pool")
     except Exception as e:
         logger.warning(

--- a/src/postgres_mcp/sql/__init__.py
+++ b/src/postgres_mcp/sql/__init__.py
@@ -9,6 +9,9 @@ from .extension_utils import check_postgres_version_requirement
 from .extension_utils import get_postgres_version
 from .extension_utils import reset_postgres_version_cache
 from .index import IndexDefinition
+from .rds_iam import RdsIamAsyncConnectionPool
+from .rds_iam import RdsIamConfig
+from .rds_iam import parse_database_uri_for_iam
 from .safe_sql import SafeSqlDriver
 from .sql_driver import DbConnPool
 from .sql_driver import SqlDriver
@@ -18,6 +21,8 @@ __all__ = [
     "ColumnCollector",
     "DbConnPool",
     "IndexDefinition",
+    "RdsIamAsyncConnectionPool",
+    "RdsIamConfig",
     "SafeSqlDriver",
     "SqlBindParams",
     "SqlDriver",
@@ -27,5 +32,6 @@ __all__ = [
     "check_postgres_version_requirement",
     "get_postgres_version",
     "obfuscate_password",
+    "parse_database_uri_for_iam",
     "reset_postgres_version_cache",
 ]

--- a/src/postgres_mcp/sql/rds_iam.py
+++ b/src/postgres_mcp/sql/rds_iam.py
@@ -1,0 +1,138 @@
+"""RDS IAM authentication support for the psycopg connection pool.
+
+RDS IAM auth tokens are short-lived (15 minutes). A static token injected at
+startup breaks the server once the token expires. This module transparently
+regenerates a fresh token every time the pool opens a new physical connection,
+so callers can treat an IAM-authenticated pool the same as a password pool.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from psycopg import AsyncConnection
+from psycopg.conninfo import conninfo_to_dict
+from psycopg.rows import TupleRow
+from psycopg_pool import AsyncConnectionPool
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RDS_PORT = 5432
+DEFAULT_SSLMODE = "require"
+
+
+@dataclass(frozen=True)
+class RdsIamConfig:
+    """Connection parameters for an RDS IAM-authenticated database.
+
+    Password is intentionally absent — it's generated per-connection by
+    `generate_token()` and has a 15-minute AWS-enforced TTL.
+    """
+
+    host: str
+    port: int
+    user: str
+    dbname: str
+    region: str
+    sslmode: str = DEFAULT_SSLMODE
+    aws_profile: Optional[str] = None
+    extra_params: Dict[str, str] = field(default_factory=dict)
+
+    def generate_token(self) -> str:
+        """Return a fresh RDS IAM auth token valid for 15 minutes."""
+        import boto3  # lazy import so non-IAM users don't pay the cost
+
+        session = boto3.Session(profile_name=self.aws_profile, region_name=self.region)
+        client = session.client("rds")
+        return client.generate_db_auth_token(
+            DBHostname=self.host,
+            Port=self.port,
+            DBUsername=self.user,
+            Region=self.region,
+        )
+
+    def base_connect_kwargs(self) -> Dict[str, Any]:
+        """Return psycopg connect kwargs with everything except the password."""
+        return {
+            "host": self.host,
+            "port": self.port,
+            "user": self.user,
+            "dbname": self.dbname,
+            "sslmode": self.sslmode,
+            **self.extra_params,
+        }
+
+
+def parse_database_uri_for_iam(
+    database_uri: str,
+    region: str,
+    aws_profile: Optional[str] = None,
+) -> RdsIamConfig:
+    """Parse a DATABASE_URI into an RdsIamConfig, discarding any password.
+
+    Accepts either postgres:// URLs or libpq key=value strings. The password
+    field, if present, is ignored — IAM auth regenerates it per-connection.
+    """
+    params = conninfo_to_dict(database_uri)
+
+    host = params.get("host")
+    user = params.get("user")
+    dbname = params.get("dbname")
+
+    missing = [name for name, val in (("host", host), ("user", user), ("dbname", dbname)) if not val]
+    if missing:
+        raise ValueError(
+            f"DATABASE_URI missing required fields for RDS IAM auth: {', '.join(missing)}. "
+            f"Expected format: postgresql://<user>@<host>:<port>/<dbname>"
+        )
+
+    port_value = params.get("port", DEFAULT_RDS_PORT)
+    try:
+        port = int(port_value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"Invalid port in DATABASE_URI: {port_value!r}") from e
+
+    sslmode = params.get("sslmode", DEFAULT_SSLMODE)
+
+    reserved = {"host", "hostaddr", "port", "user", "dbname", "password", "sslmode"}
+    extra_params = {k: str(v) for k, v in params.items() if k not in reserved}
+
+    return RdsIamConfig(
+        host=str(host),
+        port=port,
+        user=str(user),
+        dbname=str(dbname),
+        region=region,
+        sslmode=str(sslmode),
+        aws_profile=aws_profile,
+        extra_params=extra_params,
+    )
+
+
+class RdsIamAsyncConnectionPool(AsyncConnectionPool[AsyncConnection[TupleRow]]):
+    """AsyncConnectionPool that refreshes the RDS IAM token on every new
+    physical connection.
+
+    Existing pooled connections stay valid for their natural lifetime — the
+    15-minute token TTL only governs connection *establishment*, not ongoing
+    sessions. Each new connect pulls a fresh token from AWS transparently.
+    """
+
+    def __init__(self, iam_config: RdsIamConfig, **pool_kwargs: Any) -> None:
+        self._iam_config = iam_config
+        # Pass connection params via `kwargs` so we can mutate the password
+        # atomically (single dict key update) on each _connect. Using conninfo
+        # would force us to rebuild the whole string on every connect.
+        conn_kwargs = iam_config.base_connect_kwargs()
+        conn_kwargs["password"] = iam_config.generate_token()
+        super().__init__(conninfo="", kwargs=conn_kwargs, **pool_kwargs)
+
+    async def _connect(self, timeout: Optional[float] = None):  # type: ignore[override]
+        self.kwargs["password"] = self._iam_config.generate_token()  # type: ignore[index]
+        logger.debug("Refreshed RDS IAM token for new connection to %s", self._iam_config.host)
+        return await super()._connect(timeout)

--- a/src/postgres_mcp/sql/sql_driver.py
+++ b/src/postgres_mcp/sql/sql_driver.py
@@ -14,6 +14,9 @@ from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 from typing_extensions import LiteralString
 
+from .rds_iam import RdsIamAsyncConnectionPool
+from .rds_iam import RdsIamConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,21 +65,34 @@ def obfuscate_password(text: str | None) -> str | None:
 class DbConnPool:
     """Database connection manager using psycopg's connection pool."""
 
-    def __init__(self, connection_url: Optional[str] = None):
+    def __init__(
+        self,
+        connection_url: Optional[str] = None,
+        iam_config: Optional[RdsIamConfig] = None,
+    ):
         self.connection_url = connection_url
+        self.iam_config = iam_config
         self.pool: AsyncConnectionPool | None = None
         self._is_valid = False
         self._last_error = None
 
-    async def pool_connect(self, connection_url: Optional[str] = None) -> AsyncConnectionPool:
+    async def pool_connect(
+        self,
+        connection_url: Optional[str] = None,
+        iam_config: Optional[RdsIamConfig] = None,
+    ) -> AsyncConnectionPool:
         """Initialize connection pool with retry logic."""
         # If we already have a valid pool, return it
         if self.pool and self._is_valid:
             return self.pool
 
+        config = iam_config or self.iam_config
+        self.iam_config = config
+
         url = connection_url or self.connection_url
         self.connection_url = url
-        if not url:
+
+        if config is None and not url:
             self._is_valid = False
             self._last_error = "Database connection URL not provided"
             raise ValueError(self._last_error)
@@ -85,25 +101,36 @@ class DbConnPool:
         await self.close()
 
         try:
-            # Configure connection pool with appropriate settings
-            self.pool = AsyncConnectionPool(
-                conninfo=url,
-                min_size=1,
-                max_size=5,
-                open=False,  # Don't connect immediately, let's do it explicitly
-            )
+            # Local var keeps pyright narrowing happy for .open()/.connection()
+            # since the instance attribute stays typed as Optional.
+            pool: AsyncConnectionPool
+            if config is not None:
+                pool = RdsIamAsyncConnectionPool(
+                    iam_config=config,
+                    min_size=1,
+                    max_size=5,
+                    open=False,
+                )
+            else:
+                pool = AsyncConnectionPool(
+                    conninfo=url,  # type: ignore[arg-type]  # guarded above
+                    min_size=1,
+                    max_size=5,
+                    open=False,  # Don't connect immediately, let's do it explicitly
+                )
+            self.pool = pool
 
             # Open the pool explicitly
-            await self.pool.open()
+            await pool.open()
 
             # Test the connection pool by executing a simple query
-            async with self.pool.connection() as conn:
+            async with pool.connection() as conn:
                 async with conn.cursor() as cursor:
                     await cursor.execute("SELECT 1")
 
             self._is_valid = True
             self._last_error = None
-            return self.pool
+            return pool
         except Exception as e:
             self._is_valid = False
             self._last_error = str(e)

--- a/tests/unit/sql/test_rds_iam.py
+++ b/tests/unit/sql/test_rds_iam.py
@@ -1,0 +1,213 @@
+"""Unit tests for RDS IAM auth support."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from postgres_mcp.sql.rds_iam import DEFAULT_RDS_PORT
+from postgres_mcp.sql.rds_iam import DEFAULT_SSLMODE
+from postgres_mcp.sql.rds_iam import RdsIamAsyncConnectionPool
+from postgres_mcp.sql.rds_iam import RdsIamConfig
+from postgres_mcp.sql.rds_iam import parse_database_uri_for_iam
+
+# ----- parse_database_uri_for_iam -----
+
+
+def test_parse_url_form():
+    cfg = parse_database_uri_for_iam(
+        "postgresql://alice@db.example.com:5433/appdb?sslmode=require",
+        region="us-west-2",
+        aws_profile="dev",
+    )
+    assert cfg.host == "db.example.com"
+    assert cfg.port == 5433
+    assert cfg.user == "alice"
+    assert cfg.dbname == "appdb"
+    assert cfg.region == "us-west-2"
+    assert cfg.sslmode == "require"
+    assert cfg.aws_profile == "dev"
+    assert cfg.extra_params == {}
+
+
+def test_parse_keyword_form():
+    cfg = parse_database_uri_for_iam(
+        "host=db.example.com port=5432 user=alice dbname=appdb",
+        region="us-east-1",
+    )
+    assert cfg.host == "db.example.com"
+    assert cfg.port == 5432
+    assert cfg.user == "alice"
+    assert cfg.dbname == "appdb"
+    assert cfg.region == "us-east-1"
+    assert cfg.aws_profile is None
+
+
+def test_parse_drops_password():
+    """Any password in the URI must be discarded — IAM auth regenerates it."""
+    cfg = parse_database_uri_for_iam(
+        "postgresql://alice:stale-password@db.example.com/appdb",
+        region="us-west-2",
+    )
+    assert "password" not in cfg.base_connect_kwargs()
+
+
+def test_parse_default_port():
+    cfg = parse_database_uri_for_iam(
+        "postgresql://alice@db.example.com/appdb",
+        region="us-west-2",
+    )
+    assert cfg.port == DEFAULT_RDS_PORT
+
+
+def test_parse_default_sslmode():
+    cfg = parse_database_uri_for_iam(
+        "postgresql://alice@db.example.com/appdb",
+        region="us-west-2",
+    )
+    assert cfg.sslmode == DEFAULT_SSLMODE
+
+
+def test_parse_preserves_extra_params():
+    cfg = parse_database_uri_for_iam(
+        "postgresql://alice@db.example.com/appdb?application_name=mcp&connect_timeout=5",
+        region="us-west-2",
+    )
+    assert cfg.extra_params == {"application_name": "mcp", "connect_timeout": "5"}
+
+
+@pytest.mark.parametrize(
+    "uri,missing",
+    [
+        ("postgresql://db.example.com/appdb", "user"),
+        ("postgresql://alice@/appdb", "host"),
+        ("postgresql://alice@db.example.com/", "dbname"),
+    ],
+)
+def test_parse_missing_fields(uri: str, missing: str):
+    with pytest.raises(ValueError, match=missing):
+        parse_database_uri_for_iam(uri, region="us-west-2")
+
+
+def test_parse_bad_port():
+    with pytest.raises(ValueError, match="Invalid port"):
+        parse_database_uri_for_iam(
+            "host=db.example.com port=notaport user=alice dbname=appdb",
+            region="us-west-2",
+        )
+
+
+# ----- RdsIamConfig.generate_token -----
+
+
+def test_generate_token_uses_session_args():
+    with patch("boto3.Session") as mock_session_cls:
+        mock_client = MagicMock()
+        mock_client.generate_db_auth_token.return_value = "FRESH-TOKEN"
+        mock_session_cls.return_value.client.return_value = mock_client
+
+        cfg = RdsIamConfig(
+            host="db.example.com",
+            port=5432,
+            user="alice",
+            dbname="appdb",
+            region="us-west-2",
+            aws_profile="dev",
+        )
+        token = cfg.generate_token()
+
+        assert token == "FRESH-TOKEN"
+        mock_session_cls.assert_called_once_with(profile_name="dev", region_name="us-west-2")
+        mock_session_cls.return_value.client.assert_called_once_with("rds")
+        mock_client.generate_db_auth_token.assert_called_once_with(
+            DBHostname="db.example.com",
+            Port=5432,
+            DBUsername="alice",
+            Region="us-west-2",
+        )
+
+
+def test_generate_token_no_profile_passes_none():
+    with patch("boto3.Session") as mock_session_cls:
+        mock_session_cls.return_value.client.return_value.generate_db_auth_token.return_value = "T"
+        cfg = RdsIamConfig(
+            host="h",
+            port=5432,
+            user="u",
+            dbname="d",
+            region="us-west-2",
+        )
+        cfg.generate_token()
+        mock_session_cls.assert_called_once_with(profile_name=None, region_name="us-west-2")
+
+
+# ----- RdsIamConfig.base_connect_kwargs -----
+
+
+def test_base_connect_kwargs_no_password():
+    cfg = RdsIamConfig(host="h", port=5432, user="u", dbname="d", region="us-west-2")
+    kwargs = cfg.base_connect_kwargs()
+    assert "password" not in kwargs
+    assert kwargs == {"host": "h", "port": 5432, "user": "u", "dbname": "d", "sslmode": "require"}
+
+
+def test_base_connect_kwargs_merges_extras():
+    cfg = RdsIamConfig(
+        host="h",
+        port=5432,
+        user="u",
+        dbname="d",
+        region="us-west-2",
+        extra_params={"application_name": "mcp"},
+    )
+    assert cfg.base_connect_kwargs()["application_name"] == "mcp"
+
+
+# ----- RdsIamAsyncConnectionPool -----
+
+
+@pytest.fixture
+def iam_config():
+    return RdsIamConfig(
+        host="db.example.com",
+        port=5432,
+        user="alice",
+        dbname="appdb",
+        region="us-west-2",
+    )
+
+
+def test_pool_init_seeds_initial_token(iam_config: RdsIamConfig):
+    with patch.object(RdsIamConfig, "generate_token", return_value="INIT-TOKEN") as gen:
+        pool = RdsIamAsyncConnectionPool(iam_config=iam_config, open=False, min_size=0, max_size=1)
+        try:
+            assert pool.kwargs["password"] == "INIT-TOKEN"
+            assert pool.kwargs["host"] == "db.example.com"
+            assert pool.kwargs["user"] == "alice"
+            assert gen.call_count == 1
+        finally:
+            # No pool was opened, but be safe
+            pass
+
+
+@pytest.mark.asyncio
+async def test_pool_refreshes_token_on_each_connect(iam_config: RdsIamConfig):
+    """Every call to _connect must regenerate the token and call super()._connect."""
+    tokens = iter(["T1", "T2", "T3"])
+    with patch.object(RdsIamConfig, "generate_token", side_effect=lambda: next(tokens)):
+        pool = RdsIamAsyncConnectionPool(iam_config=iam_config, open=False, min_size=0, max_size=1)
+        # Initial token was "T1" (consumed in __init__)
+        assert pool.kwargs["password"] == "T1"
+
+        with patch(
+            "psycopg_pool.AsyncConnectionPool._connect",
+            new=AsyncMock(return_value=MagicMock(name="fake_conn")),
+        ) as super_connect:
+            await pool._connect()
+            assert pool.kwargs["password"] == "T2"
+            assert super_connect.await_count == 1
+
+            await pool._connect()
+            assert pool.kwargs["password"] == "T3"
+            assert super_connect.await_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -105,6 +105,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.95"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/33/1e44193d5419683bf9dc121108407cbd6ebe73e17f5615cb62c68fae97b1/boto3-1.42.95.tar.gz", hash = "sha256:1cb77a269596abe05e72ed44a26167e7a620df920edb7c65e7d8a7dd39b427d5", size = 113226, upload-time = "2026-04-23T21:35:36.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/c6/8908d18c0fbef8edb62791e1a5b8ff33b816b1a9b9dff360159befdb8fac/boto3-1.42.95-py3-none-any.whl", hash = "sha256:f0175de8f52448e9ecade9573532c25bed390a7c30435920a0da42a10f4cafb3", size = 140557, upload-time = "2026-04-23T21:35:33.906Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.95"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/29/a6d95515b49357891f63cb7a93fef37334118ba7d11d686d139e5d648733/botocore-1.42.95.tar.gz", hash = "sha256:f23a78b76def67222ddac738fb65475f55d17fd88c1e18573b3a561135ec4527", size = 15260896, upload-time = "2026-04-23T21:35:22.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/ee/b08867e183922dd356d2d8f23bafd7bb6b24c5992bdb301873edbb096e2d/botocore-1.42.95-py3-none-any.whl", hash = "sha256:3381279d26792df2fcc3d5d7fa052ecf1949a0fe1ea819bf35d61e943c15a3b6", size = 14943430, upload-time = "2026-04-23T21:35:18.976Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -598,6 +626,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -875,6 +912,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
+    { name = "boto3" },
     { name = "humanize" },
     { name = "instructor" },
     { name = "mcp", extra = ["cli"] },
@@ -895,12 +933,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=25.4.0" },
+    { name = "boto3", specifier = ">=1.34.0" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "instructor", specifier = ">=1.14.4" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
     { name = "pglast", specifier = "==7.11" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.2" },
-    { name = "psycopg-pool", specifier = ">=3.3.0" },
+    { name = "psycopg-pool", specifier = ">=3.3.0,<4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1200,6 +1239,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1426,12 +1477,33 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524", size = 154801, upload-time = "2026-04-22T20:36:06.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2", size = 86825, upload-time = "2026-04-22T20:36:04.992Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
RDS IAM auth tokens expire after 15 minutes, so injecting a static token at startup breaks the server once it expires. This change adds a new --auth-type=rds-iam mode that generates a fresh token on every physical connection the pool opens, making token rotation transparent to callers.

- New rds_iam module with RdsIamConfig, token generator, and a RdsIamAsyncConnectionPool subclass that overrides _connect to refresh the password immediately before each psycopg.AsyncConnection.connect.
- DbConnPool accepts an optional iam_config and switches pool class accordingly; password auth path is unchanged.
- New CLI flags: --auth-type, --aws-region, --aws-profile. DATABASE_URI password is stripped when IAM mode is active; sslmode=require is applied by default since RDS rejects plaintext IAM auth.
- Adds boto3>=1.34.0; pins psycopg-pool<4 to keep the AsyncConnectionPool subclass contract stable.
- 16 unit tests covering token generation, config parsing, URI handling, pool refresh on _connect, and error paths (missing region, boto3 failures).