### PR TITLE
chore: migrate to mcpb-pack@v3 (drop server.json)

### DIFF
--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -1,73 +1,45 @@
 name: Build MCPB Bundle
 
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to build (e.g., 0.3.0)'
-        required: true
-        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
   build:
-    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
-          - runner: ubuntu-latest
+          - os: linux
             arch: amd64
-          - runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
+          - os: linux
             arch: arm64
+            runner: ubuntu-24.04-arm
+          - os: darwin
+            arch: arm64
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Update manifest version
         run: |
-          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' manifest.json > manifest.tmp.json
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          jq --arg v "$VERSION" '.version = $v' manifest.json > manifest.tmp.json
           mv manifest.tmp.json manifest.json
 
       # pglast requires make for compilation
-      - name: Install build dependencies
+      - name: Install build dependencies (Linux)
+        if: matrix.os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - uses: NimbleBrainInc/mcpb-pack@v1
-        id: pack
+      - uses: NimbleBrainInc/mcpb-pack@v2
         with:
-          python-version: '3.14'
-          output: mcp-postgres-v${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.mcpb
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: bundle-${{ matrix.arch }}
-          path: ${{ steps.pack.outputs.bundle-path }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*.mcpb
-          generate_release_notes: true
+          output: "{name}-{version}-${{ matrix.os }}-${{ matrix.arch }}.mcpb"

--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -1,0 +1,73 @@
+name: Build MCPB Bundle
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 0.3.0)'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update manifest version
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' manifest.json > manifest.tmp.json
+          mv manifest.tmp.json manifest.json
+
+      # pglast requires make for compilation
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - uses: NimbleBrainInc/mcpb-pack@v1
+        id: pack
+        with:
+          python-version: '3.14'
+          output: mcp-postgres-v${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}.mcpb
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-${{ matrix.arch }}
+          path: ${{ steps.pack.outputs.bundle-path }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.mcpb
+          generate_release_notes: true

--- a/.github/workflows/build-bundle.yml
+++ b/.github/workflows/build-bundle.yml
@@ -40,6 +40,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
 
-      - uses: NimbleBrainInc/mcpb-pack@v2
+      - uses: NimbleBrainInc/mcpb-pack@v3
         with:
           output: "{name}-{version}-${{ matrix.os }}-${{ matrix.arch }}.mcpb"

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,7 @@ devenv.local.nix
 # pre-commit
 .pre-commit-config.yaml
 *.sql
+
+# MCPB build artifacts
+deps/
+*.mcpb

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,63 @@
+# Build artifacts
+.venv/
+.git/
+.github/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+.eggs/
+
+# Test and dev files
+tests/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# Linting and type checking caches
+.mypy_cache/
+.ruff_cache/
+.pytype/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Environment and secrets
+.env
+.env.*
+*.local
+
+# Documentation and assets
+*.md
+*.rst
+docs/
+assets/
+examples/
+
+# Development config
+devenv.nix
+devenv.yaml
+devenv.lock
+justfile
+smithery.yaml
+Dockerfile
+docker-entrypoint.sh
+.python-version
+Makefile
+pytest.ini
+pyproject.toml
+uv.lock
+
+# Bundle artifacts
+*.mcpb

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default code owners for all NimbleBrainInc repositories.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @NimbleBrainInc/core

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "ai.nimbletools/postgres",
-  "version": "0.3.1-mcpb.1",
+  "version": "0.3.1-mcpb.2",
   "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
   "author": {
     "name": "Crystal DBA (packaged by NimbleBrain Inc)"
@@ -12,6 +12,13 @@
     "mcp_config": {
       "command": "python",
       "args": ["-c", "from postgres_mcp import main; main()"]
+    }
+  },
+  "user_config": {
+    "DATABASE_URI": {
+      "description": "PostgreSQL connection string (e.g., postgresql://user:password@host:5432/database)",
+      "required": true,
+      "env": "DATABASE_URI"
     }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "ai.nimbletools/postgres",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
   "author": {
     "name": "Crystal DBA (packaged by NimbleBrain Inc)"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "ai.nimbletools/postgres",
-  "version": "0.3.1",
+  "version": "0.3.1-mcpb.1",
   "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
   "author": {
     "name": "Crystal DBA (packaged by NimbleBrain Inc)"

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": "0.3",
+  "name": "ai.nimbletools/postgres",
+  "version": "0.3.0",
+  "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
+  "author": {
+    "name": "Crystal DBA (packaged by NimbleBrain Inc)"
+  },
+  "server": {
+    "type": "python",
+    "entry_point": "postgres_mcp/__init__.py",
+    "mcp_config": {
+      "command": "python",
+      "args": ["-c", "from postgres_mcp import main; main()"]
+    }
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
-  "name": "ai.nimbletools/postgres",
-  "version": "0.3.1-mcpb.3",
+  "name": "@nimblebraininc/postgres",
+  "version": "0.3.1-mcpb.4",
   "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
   "author": {
     "name": "Crystal DBA (packaged by NimbleBrain Inc)"

--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,29 @@
 {
   "manifest_version": "0.3",
   "name": "ai.nimbletools/postgres",
-  "version": "0.3.1-mcpb.2",
+  "version": "0.3.1-mcpb.3",
   "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
   "author": {
     "name": "Crystal DBA (packaged by NimbleBrain Inc)"
+  },
+  "user_config": {
+    "database_uri": {
+      "type": "string",
+      "title": "Database URI",
+      "description": "PostgreSQL connection string (e.g., postgresql://user:password@host:5432/database)",
+      "sensitive": true,
+      "required": true
+    }
   },
   "server": {
     "type": "python",
     "entry_point": "postgres_mcp/__init__.py",
     "mcp_config": {
       "command": "python",
-      "args": ["-c", "from postgres_mcp import main; main()"]
-    }
-  },
-  "user_config": {
-    "DATABASE_URI": {
-      "description": "PostgreSQL connection string (e.g., postgresql://user:password@host:5432/database)",
-      "required": true,
-      "env": "DATABASE_URI"
+      "args": ["-c", "from postgres_mcp import main; main()"],
+      "env": {
+        "DATABASE_URI": "${user_config.database_uri}"
+      }
     }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": "0.3",
   "name": "@nimblebraininc/postgres",
-  "version": "0.3.1-mcpb.4",
+  "version": "0.3.1-mcpb.5",
   "description": "PostgreSQL MCP server with AI-powered tuning, index optimization, and database health analysis",
   "author": {
     "name": "Crystal DBA (packaged by NimbleBrain Inc)"
   },
+  "icon": "https://static.nimblebrain.ai/icons/postgresql.png",
   "user_config": {
     "database_uri": {
       "type": "string",
@@ -20,7 +21,10 @@
     "entry_point": "postgres_mcp/__init__.py",
     "mcp_config": {
       "command": "python",
-      "args": ["-c", "from postgres_mcp import main; main()"],
+      "args": [
+        "-c",
+        "from postgres_mcp import main; main()"
+      ],
       "env": {
         "DATABASE_URI": "${user_config.database_uri}"
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "postgres-mcp"
-version = "0.3.0"
+version = "0.3.1-mcpb.5"
 description = "PostgreSQL Tuning and Analysis Tool"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Delete `server.json` from this bundle. mpak now composes the MCP registry's [`ServerDetail`](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/draft/server.schema.json) discovery shape from `manifest.json` server-side, so the per-bundle file is unused.
- Drop the workflow step that bumped `server.json::version` from `manifest.json`.
- Bump `NimbleBrainInc/mcpb-pack@v2` → `@v3` in the release workflow.

## Optional follow-up

Add a branded reverse-DNS name override in `manifest.json` if you want a non-default registry name:

```json
{
  "_meta": {
    "dev.mpak/registry": {
      "name": "ai.nimblebrain/<bundle-name>"
    }
  }
}
```

Without an override the registry uses the mechanical default `dev.mpak.<scope>/<name>`.

## Test plan

- [ ] Cut a release and confirm the build workflow succeeds against `mcpb-pack@v3`
- [ ] Verify the bundle appears at `https://registry.mpak.dev/v1/servers/<name>` after announce