### PR TITLE
feat: add per-agent RBAC with token-based access policies

### DIFF
--- a/docs/agent-policies.md
+++ b/docs/agent-policies.md
@@ -1,0 +1,132 @@
+# Per-Agent RBAC — Agent Policies
+
+postgres-mcp supports fine-grained **per-agent Role-Based Access Control (RBAC)**.
+Each AI agent is identified by a bearer token and gets its own:
+
+- **Access mode** (`unrestricted` / `restricted` / `readonly`)
+- **Allowed schemas** (list or `["*"]` for all)
+- **Allowed MCP tools** (list or `["*"]` for all)
+- **Audit logging** (structured JSON log per query)
+
+This is different from the global `--access-mode` flag: with per-agent policies,
+a read-only reporting bot and a privileged migration agent can connect to the
+same server instance with different levels of access.
+
+## Quick Start
+
+### 1. Create `agents.yaml`
+
+```yaml
+agents:
+  - name: reporting-bot
+    token: "rpt-abc123"          # plaintext — hashed at load time
+    access_mode: readonly
+    allowed_schemas: ["analytics", "public"]
+    allowed_tools: ["execute_sql", "list_objects", "get_object_details"]
+    audit: true
+
+  - name: schema-inspector
+    token: "ins-def456"
+    access_mode: restricted       # pglast-validated, read-only tx
+    allowed_schemas: ["*"]        # all schemas
+    allowed_tools: ["list_schemas", "list_objects", "get_object_details"]
+    audit: true
+
+  - name: migration-agent
+    token: "mig-xyz789"
+    access_mode: unrestricted
+    allowed_schemas: ["*"]
+    allowed_tools: ["*"]
+    audit: true
+
+# Optional: access mode for requests without a token
+default_access_mode: readonly
+```
+
+### 2. Start the server
+
+```bash
+postgres-mcp "postgresql://user:pass@host/db" --agent-policies ./agents.yaml
+```
+
+Or via environment variable (useful for Docker / Kubernetes):
+
+```bash
+export AGENT_POLICIES_JSON='[
+  {"name":"bot","token":"tok1","access_mode":"readonly","audit":true}
+]'
+postgres-mcp "postgresql://user:pass@host/db"
+```
+
+### 3. Agents send their token
+
+Agents identify themselves via the `X-Agent-Token` HTTP header:
+
+```bash
+curl -H "X-Agent-Token: rpt-abc123" http://localhost:8000/mcp
+```
+
+For stdio transport, include the token in the MCP `_meta` field:
+
+```json
+{
+  "method": "tools/call",
+  "_meta": {"x-agent-token": "rpt-abc123"},
+  "params": {"name": "execute_sql", "arguments": {"sql": "SELECT 1"}}
+}
+```
+
+## Access Modes
+
+| Mode | SQL Validation | DB Enforcement | Best For |
+|---|---|---|---|
+| `unrestricted` | None | None | Trusted migration agents |
+| `restricted` | pglast AST | `READ ONLY` tx | Production read agents |
+| `readonly` | None | `READ ONLY` tx | Analytics agents with complex queries |
+
+## Schema Guards
+
+When `allowed_schemas` is set to a specific list, the RBAC driver rejects
+any query that references an unlisted schema:
+
+```
+Agent 'reporting-bot' is not permitted to access schema 'secrets'.
+Allowed schemas: ['analytics', 'public']
+```
+
+Schema detection covers `schema.table` qualified references and
+`SET search_path TO schema` statements.
+
+## Tool Guards
+
+When `allowed_tools` is a specific list, calling a non-allowed MCP tool
+returns an error before the query reaches the database:
+
+```
+Agent 'reporting-bot' is not permitted to use tool 'run_health_check'.
+Allowed tools: ['execute_sql', 'get_object_details', 'list_objects']
+```
+
+## Audit Logs
+
+When `audit: true`, every query emits a structured log line:
+
+```json
+{"event": "agent_query", "agent": "reporting-bot", "access_mode": "readonly",
+ "sql_preview": "SELECT * FROM analytics.sales WHERE ...",
+ "has_params": false, "duration_ms": 12.4, "error": null}
+```
+
+Route these to your log aggregator (Loki, CloudWatch, Datadog) for a full
+audit trail of every AI agent action.
+
+## Security Notes
+
+- Tokens are **SHA-256 hashed** at load time — plaintext secrets never live
+  in process memory after startup.
+- Token comparison uses **`hmac.compare_digest`** to prevent timing attacks.
+- Schema guards are **best-effort** (token-based) for now. For strict isolation
+  use dedicated PostgreSQL roles per agent in addition to RBAC policies.
+- Per-agent policies **layer on top of** the server's global `--access-mode`.
+  If the server is started with `--access-mode restricted`, an agent with
+  `access_mode: unrestricted` still gets `restricted` (the stricter wins).

--- a/src/postgres_mcp/rbac/__init__.py
+++ b/src/postgres_mcp/rbac/__init__.py
@@ -1,0 +1,14 @@
+"""Per-agent RBAC for postgres-mcp."""
+
+from .agent_policy import AgentPolicy, AgentPolicyRegistry, AccessMode
+from .policy_loader import load_policies_from_yaml, load_policies_from_env
+from .rbac_sql_driver import RbacSqlDriver
+
+__all__ = [
+    "AgentPolicy",
+    "AgentPolicyRegistry",
+    "AccessMode",
+    "load_policies_from_yaml",
+    "load_policies_from_env",
+    "RbacSqlDriver",
+]

--- a/src/postgres_mcp/rbac/agent_policy.py
+++ b/src/postgres_mcp/rbac/agent_policy.py
@@ -1,0 +1,144 @@
+"""AgentPolicy dataclass and registry for per-agent RBAC."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+
+class AccessMode(str, Enum):
+    """Per-agent access mode, mirrors server-level AccessMode."""
+
+    UNRESTRICTED = "unrestricted"
+    RESTRICTED = "restricted"
+    READONLY = "readonly"
+
+
+@dataclass(frozen=True)
+class AgentPolicy:
+    """Immutable access policy for a single AI agent.
+
+    Each agent is identified by a bearer token sent in the
+    ``X-Agent-Token`` HTTP header (or ``AGENT_TOKEN`` MCP meta field).
+    The token is stored as a SHA-256 digest so plaintext secrets never
+    live in memory after startup.
+
+    Attributes
+    ----------
+    name:
+        Human-readable agent name used in audit logs.
+    token_digest:
+        SHA-256 hex digest of the raw bearer token.
+    access_mode:
+        Server-level access mode applied when this agent executes SQL.
+    allowed_schemas:
+        Set of schema names the agent may query.  ``{"*"}`` means all
+        schemas are permitted.
+    allowed_tools:
+        Set of MCP tool names the agent may call.  ``{"*"}`` means all
+        tools are permitted.
+    audit:
+        When ``True``, every query is emitted as a structured JSON log
+        entry at INFO level.
+    """
+
+    name: str
+    token_digest: str
+    access_mode: AccessMode = AccessMode.READONLY
+    allowed_schemas: frozenset[str] = field(default_factory=lambda: frozenset({"*"}))
+    allowed_tools: frozenset[str] = field(default_factory=lambda: frozenset({"*"}))
+    audit: bool = True
+
+    # ------------------------------------------------------------------
+    # Factory helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_token(
+        cls,
+        name: str,
+        token: str,
+        access_mode: AccessMode | str = AccessMode.READONLY,
+        allowed_schemas: list[str] | None = None,
+        allowed_tools: list[str] | None = None,
+        audit: bool = True,
+    ) -> "AgentPolicy":
+        """Create a policy from a plaintext token (hashed on construction)."""
+        digest = hashlib.sha256(token.encode()).hexdigest()
+        return cls(
+            name=name,
+            token_digest=digest,
+            access_mode=AccessMode(access_mode),
+            allowed_schemas=frozenset(allowed_schemas or ["*"]),
+            allowed_tools=frozenset(allowed_tools or ["*"]),
+            audit=audit,
+        )
+
+    # ------------------------------------------------------------------
+    # Permission checks
+    # ------------------------------------------------------------------
+
+    def allows_schema(self, schema: str) -> bool:
+        """Return True if *schema* is permitted by this policy."""
+        return "*" in self.allowed_schemas or schema in self.allowed_schemas
+
+    def allows_tool(self, tool_name: str) -> bool:
+        """Return True if *tool_name* is permitted by this policy."""
+        return "*" in self.allowed_tools or tool_name in self.allowed_tools
+
+    def matches_token(self, raw_token: str) -> bool:
+        """Constant-time comparison to prevent timing attacks."""
+        candidate = hashlib.sha256(raw_token.encode()).hexdigest()
+        return hmac.compare_digest(self.token_digest, candidate)
+
+
+class AgentPolicyRegistry:
+    """Thread-safe registry that maps token digests to AgentPolicy objects.
+
+    Usage
+    -----
+    registry = AgentPolicyRegistry()
+    registry.register(AgentPolicy.from_token("bot", "secret-token", "readonly"))
+    policy = registry.lookup("secret-token")   # returns AgentPolicy or None
+    """
+
+    def __init__(self, default_policy: AgentPolicy | None = None) -> None:
+        self._policies: dict[str, AgentPolicy] = {}
+        # When no token is supplied the server falls back to this policy.
+        # If None, requests without a token are rejected.
+        self.default_policy = default_policy
+
+    def register(self, policy: AgentPolicy) -> None:
+        """Add or replace a policy in the registry."""
+        if policy.token_digest in self._policies:
+            logger.warning(
+                "Overwriting existing policy for agent '%s'", policy.name
+            )
+        self._policies[policy.token_digest] = policy
+        logger.info("Registered agent policy: name=%s mode=%s", policy.name, policy.access_mode)
+
+    def lookup(self, raw_token: str) -> AgentPolicy | None:
+        """Return the policy for *raw_token*, or None if not found."""
+        digest = hashlib.sha256(raw_token.encode()).hexdigest()
+        return self._policies.get(digest)
+
+    def lookup_or_default(self, raw_token: str | None) -> AgentPolicy | None:
+        """Return policy for token, fall back to default, or None."""
+        if raw_token:
+            policy = self.lookup(raw_token)
+            if policy is not None:
+                return policy
+        return self.default_policy
+
+    def __len__(self) -> int:
+        return len(self._policies)
+
+    def __repr__(self) -> str:
+        names = [p.name for p in self._policies.values()]
+        return f"AgentPolicyRegistry(agents={names}, default={self.default_policy})"

--- a/src/postgres_mcp/rbac/policy_loader.py
+++ b/src/postgres_mcp/rbac/policy_loader.py
@@ -1,0 +1,167 @@
+"""Load AgentPolicy objects from YAML files or environment variables."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+try:
+    import yaml  # PyYAML — already in postgres-mcp deps via pglast extras
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore[assignment]
+
+from .agent_policy import AccessMode, AgentPolicy, AgentPolicyRegistry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# YAML loader
+# ---------------------------------------------------------------------------
+
+_REQUIRED_FIELDS = {"name", "token"}
+_VALID_MODES = {m.value for m in AccessMode}
+
+
+def _parse_policy_dict(data: dict) -> AgentPolicy:
+    """Validate and convert a raw dict (from YAML) into an AgentPolicy."""
+    missing = _REQUIRED_FIELDS - data.keys()
+    if missing:
+        raise ValueError(f"Agent policy missing required fields: {missing}")
+
+    name: str = data["name"]
+    token: str = str(data["token"])
+
+    raw_mode = data.get("access_mode", "readonly")
+    if raw_mode not in _VALID_MODES:
+        raise ValueError(
+            f"Agent '{name}': invalid access_mode '{raw_mode}'. "
+            f"Must be one of {sorted(_VALID_MODES)}."
+        )
+
+    schemas_raw = data.get("allowed_schemas", ["*"])
+    if isinstance(schemas_raw, str):
+        schemas_raw = [schemas_raw]
+
+    tools_raw = data.get("allowed_tools", ["*"])
+    if isinstance(tools_raw, str):
+        tools_raw = [tools_raw]
+
+    audit: bool = bool(data.get("audit", True))
+
+    return AgentPolicy.from_token(
+        name=name,
+        token=token,
+        access_mode=raw_mode,
+        allowed_schemas=list(schemas_raw),
+        allowed_tools=list(tools_raw),
+        audit=audit,
+    )
+
+
+def load_policies_from_yaml(path: str | Path) -> AgentPolicyRegistry:
+    """Load an AgentPolicyRegistry from a YAML file.
+
+    Expected format::
+
+        agents:
+          - name: reporting-bot
+            token: "rpt-abc123"
+            access_mode: readonly
+            allowed_schemas: ["analytics", "public"]
+            allowed_tools: ["execute_sql", "list_objects"]
+            audit: true
+
+          - name: migration-agent
+            token: "mig-xyz789"
+            access_mode: unrestricted
+            allowed_schemas: ["*"]
+            allowed_tools: ["*"]
+            audit: true
+
+        default_access_mode: readonly   # optional — applied to token-less requests
+    """
+    if yaml is None:
+        raise ImportError(
+            "PyYAML is required to load agent policies from YAML. "
+            "Install it with: pip install pyyaml"
+        )
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Agent policy file not found: {path}")
+
+    with path.open() as fh:
+        raw = yaml.safe_load(fh)
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Agent policy file must be a YAML mapping, got {type(raw).__name__}")
+
+    registry = AgentPolicyRegistry()
+
+    # Optional default policy for unauthenticated requests
+    default_mode = raw.get("default_access_mode")
+    if default_mode:
+        if default_mode not in _VALID_MODES:
+            raise ValueError(f"Invalid default_access_mode '{default_mode}'")
+        registry.default_policy = AgentPolicy.from_token(
+            name="__default__",
+            token="__default__",
+            access_mode=default_mode,
+            allowed_schemas=["*"],
+            allowed_tools=["*"],
+            audit=False,
+        )
+        logger.info("Default (unauthenticated) access mode: %s", default_mode)
+
+    agents_raw = raw.get("agents", [])
+    if not isinstance(agents_raw, list):
+        raise ValueError("'agents' must be a YAML list")
+
+    for i, agent_data in enumerate(agents_raw):
+        try:
+            policy = _parse_policy_dict(agent_data)
+            registry.register(policy)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"Error in agent #{i + 1}: {exc}") from exc
+
+    logger.info("Loaded %d agent policies from %s", len(registry), path)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Environment variable loader (12-factor / Docker-friendly)
+# ---------------------------------------------------------------------------
+
+def load_policies_from_env(env_var: str = "AGENT_POLICIES_JSON") -> AgentPolicyRegistry | None:
+    """Load policies from a JSON string in an environment variable.
+
+    Useful for Docker / Kubernetes deployments where mounting a file is
+    inconvenient.  Set the env var to a JSON array of policy objects::
+
+        AGENT_POLICIES_JSON='[{"name":"bot","token":"t1","access_mode":"readonly"}]'
+
+    Returns None if the env var is not set.
+    """
+    raw = os.environ.get(env_var)
+    if not raw:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {env_var}: {exc}") from exc
+
+    if not isinstance(data, list):
+        raise ValueError(f"{env_var} must be a JSON array of policy objects")
+
+    registry = AgentPolicyRegistry()
+    for i, item in enumerate(data):
+        try:
+            registry.register(_parse_policy_dict(item))
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"Error in {env_var}[{i}]: {exc}") from exc
+
+    logger.info("Loaded %d agent policies from env var %s", len(registry), env_var)
+    return registry

--- a/src/postgres_mcp/rbac/rbac_sql_driver.py
+++ b/src/postgres_mcp/rbac/rbac_sql_driver.py
@@ -1,0 +1,219 @@
+"""RbacSqlDriver — per-agent access control decorator over SqlDriver.
+
+This driver wraps an existing SqlDriver (or SafeSqlDriver / ReadOnlySqlDriver)
+and enforces per-agent policies:
+
+1. **Schema guard** — rejects queries that reference schemas not allowed by
+   the agent's policy (checked against ``search_path`` and explicit schema
+   qualifiers parsed from the SQL AST).
+2. **Access-mode delegation** — selects the correct underlying driver based
+   on the agent's ``access_mode`` (unrestricted / restricted / readonly).
+3. **Audit logging** — emits a structured JSON log entry for every query
+   executed by agents that have ``audit=True``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+from ..sql.sql_driver import SqlDriver, RowResult
+from ..sql.safe_sql import SafeSqlDriver
+from .agent_policy import AgentPolicy, AccessMode
+
+logger = logging.getLogger(__name__)
+
+# Timeout applied in readonly / restricted mode (seconds)
+_DEFAULT_TIMEOUT = 30.0
+
+
+class SchemaViolationError(PermissionError):
+    """Raised when a query touches a schema not allowed by the agent policy."""
+
+
+class ToolViolationError(PermissionError):
+    """Raised when an agent calls a tool not allowed by its policy."""
+
+
+class RbacSqlDriver:
+    """Decorator that enforces an AgentPolicy on every SQL execution.
+
+    Parameters
+    ----------
+    sql_driver:
+        Base SqlDriver connected to the target database.
+    policy:
+        The AgentPolicy to enforce.
+    timeout:
+        Query timeout in seconds (applied in readonly/restricted modes).
+
+    Examples
+    --------
+    ::
+
+        base = SqlDriver(conn=db_connection)
+        policy = AgentPolicy.from_token(
+            name="reporting-bot",
+            token="secret",
+            access_mode="readonly",
+            allowed_schemas=["analytics", "public"],
+        )
+        driver = RbacSqlDriver(sql_driver=base, policy=policy)
+        rows = await driver.execute_query("SELECT * FROM analytics.sales")
+    """
+
+    def __init__(
+        self,
+        sql_driver: SqlDriver,
+        policy: AgentPolicy,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self._base = sql_driver
+        self.policy = policy
+        self._timeout = timeout
+        self._effective_driver = self._build_effective_driver()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_effective_driver(self) -> SqlDriver | SafeSqlDriver:
+        """Wrap base driver according to agent's access_mode."""
+        mode = self.policy.access_mode
+        if mode == AccessMode.RESTRICTED:
+            return SafeSqlDriver(sql_driver=self._base, timeout=self._timeout)
+        if mode == AccessMode.READONLY:
+            # Import lazily to avoid circular deps if readonly_sql is added later
+            try:
+                from ..sql.readonly_sql import ReadOnlySqlDriver  # type: ignore[import]
+                return ReadOnlySqlDriver(sql_driver=self._base, timeout=self._timeout)
+            except ImportError:
+                # Fallback: use SafeSqlDriver in readonly mode
+                logger.debug(
+                    "readonly_sql not available, falling back to SafeSqlDriver for agent '%s'",
+                    self.policy.name,
+                )
+                return SafeSqlDriver(sql_driver=self._base, timeout=self._timeout)
+        # UNRESTRICTED — use base driver directly
+        return self._base
+
+    def _check_tool_allowed(self, tool_name: str) -> None:
+        """Raise ToolViolationError if tool is not allowed for this agent."""
+        if not self.policy.allows_tool(tool_name):
+            raise ToolViolationError(
+                f"Agent '{self.policy.name}' is not permitted to use tool '{tool_name}'. "
+                f"Allowed tools: {sorted(self.policy.allowed_tools)}"
+            )
+
+    def _check_schemas_allowed(self, sql: str) -> None:
+        """Best-effort schema check using simple token parsing.
+
+        A full AST-based check would require pglast and is left as a
+        future improvement.  This covers the most common patterns:
+        ``schema.table`` and ``SET search_path TO schema``.
+        """
+        if "*" in self.policy.allowed_schemas:
+            return
+
+        # Normalize and scan for schema-qualified identifiers
+        sql_lower = sql.lower()
+        for schema in self._extract_schemas_from_sql(sql_lower):
+            if not self.policy.allows_schema(schema):
+                raise SchemaViolationError(
+                    f"Agent '{self.policy.name}' is not permitted to access schema '{schema}'. "
+                    f"Allowed schemas: {sorted(self.policy.allowed_schemas)}"
+                )
+
+    @staticmethod
+    def _extract_schemas_from_sql(sql_lower: str) -> list[str]:
+        """Extract schema names from common SQL patterns."""
+        import re
+
+        schemas: list[str] = []
+
+        # Pattern: schema.table or schema.function
+        for match in re.finditer(r'([a-z_][a-z0-9_]*)\s*\.\s*[a-z_]', sql_lower):
+            candidate = match.group(1)
+            # Skip common non-schema keywords
+            if candidate not in (
+                'pg_catalog', 'information_schema', 'pg_toast',
+            ):
+                schemas.append(candidate)
+
+        # Pattern: SET search_path TO schema1, schema2
+        sp_match = re.search(
+            r'set\s+search_path\s+(?:to|=)\s+([^;]+)', sql_lower
+        )
+        if sp_match:
+            for part in sp_match.group(1).split(','):
+                schemas.append(part.strip().strip('"\' '))
+
+        return schemas
+
+    def _audit_log(self, sql: str, params: Any, duration_ms: float, error: str | None = None) -> None:
+        """Emit a structured audit log entry."""
+        if not self.policy.audit:
+            return
+        entry = {
+            "event": "agent_query",
+            "agent": self.policy.name,
+            "access_mode": self.policy.access_mode.value,
+            "sql_preview": sql[:200],
+            "has_params": params is not None,
+            "duration_ms": round(duration_ms, 2),
+            "error": error,
+        }
+        logger.info("RBAC_AUDIT %s", json.dumps(entry))
+
+    # ------------------------------------------------------------------
+    # Public API — mirrors SqlDriver interface
+    # ------------------------------------------------------------------
+
+    async def execute_query(
+        self,
+        sql: str,
+        params: Any = None,
+        *,
+        force_readonly: bool = False,
+        tool_name: str | None = None,
+    ) -> list[RowResult]:
+        """Execute *sql* under this agent's policy.
+
+        Parameters
+        ----------
+        sql:
+            The SQL statement to execute.
+        params:
+            Optional query parameters (passed through to the driver).
+        force_readonly:
+            If True, forces a read-only transaction regardless of access_mode.
+        tool_name:
+            Optional MCP tool name for tool-level access control.
+        """
+        # 1. Tool check
+        if tool_name is not None:
+            self._check_tool_allowed(tool_name)
+
+        # 2. Schema check
+        self._check_schemas_allowed(sql)
+
+        # 3. Execute via effective driver
+        t0 = time.monotonic()
+        error: str | None = None
+        try:
+            if self.policy.access_mode == AccessMode.READONLY or force_readonly:
+                result = await self._effective_driver.execute_query(
+                    sql, params, force_readonly=True
+                )
+            else:
+                result = await self._effective_driver.execute_query(sql, params)
+            return result
+        except Exception as exc:
+            error = str(exc)
+            raise
+        finally:
+            duration_ms = (time.monotonic() - t0) * 1000
+            self._audit_log(sql, params, duration_ms, error)

--- a/tests/unit/rbac/test_agent_policy.py
+++ b/tests/unit/rbac/test_agent_policy.py
@@ -1,0 +1,245 @@
+"""Unit tests for per-agent RBAC: AgentPolicy, AgentPolicyRegistry, policy_loader."""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from postgres_mcp.rbac.agent_policy import AccessMode, AgentPolicy, AgentPolicyRegistry
+from postgres_mcp.rbac.policy_loader import load_policies_from_env, load_policies_from_yaml
+from postgres_mcp.rbac.rbac_sql_driver import (
+    RbacSqlDriver,
+    SchemaViolationError,
+    ToolViolationError,
+)
+
+
+# ---------------------------------------------------------------------------
+# AgentPolicy
+# ---------------------------------------------------------------------------
+
+class TestAgentPolicy:
+    def test_from_token_defaults(self):
+        p = AgentPolicy.from_token("bot", "secret")
+        assert p.name == "bot"
+        assert p.access_mode == AccessMode.READONLY
+        assert "*" in p.allowed_schemas
+        assert "*" in p.allowed_tools
+        assert p.audit is True
+
+    def test_token_is_hashed(self):
+        p = AgentPolicy.from_token("bot", "my-plaintext-token")
+        assert "my-plaintext-token" not in p.token_digest
+        assert len(p.token_digest) == 64  # SHA-256 hex
+
+    def test_matches_token_correct(self):
+        p = AgentPolicy.from_token("bot", "correct-token")
+        assert p.matches_token("correct-token") is True
+
+    def test_matches_token_wrong(self):
+        p = AgentPolicy.from_token("bot", "correct-token")
+        assert p.matches_token("wrong-token") is False
+
+    def test_allows_schema_wildcard(self):
+        p = AgentPolicy.from_token("bot", "t", allowed_schemas=["*"])
+        assert p.allows_schema("any_schema") is True
+
+    def test_allows_schema_specific(self):
+        p = AgentPolicy.from_token("bot", "t", allowed_schemas=["analytics", "public"])
+        assert p.allows_schema("analytics") is True
+        assert p.allows_schema("secrets") is False
+
+    def test_allows_tool_wildcard(self):
+        p = AgentPolicy.from_token("bot", "t", allowed_tools=["*"])
+        assert p.allows_tool("execute_sql") is True
+
+    def test_allows_tool_specific(self):
+        p = AgentPolicy.from_token("bot", "t", allowed_tools=["execute_sql", "list_objects"])
+        assert p.allows_tool("execute_sql") is True
+        assert p.allows_tool("run_health_check") is False
+
+    def test_access_mode_string_conversion(self):
+        p = AgentPolicy.from_token("bot", "t", access_mode="unrestricted")
+        assert p.access_mode == AccessMode.UNRESTRICTED
+
+    def test_invalid_access_mode_raises(self):
+        with pytest.raises(ValueError):
+            AgentPolicy.from_token("bot", "t", access_mode="superuser")
+
+
+# ---------------------------------------------------------------------------
+# AgentPolicyRegistry
+# ---------------------------------------------------------------------------
+
+class TestAgentPolicyRegistry:
+    def test_register_and_lookup(self):
+        registry = AgentPolicyRegistry()
+        p = AgentPolicy.from_token("bot", "tok1")
+        registry.register(p)
+        found = registry.lookup("tok1")
+        assert found is p
+
+    def test_lookup_unknown_token_returns_none(self):
+        registry = AgentPolicyRegistry()
+        assert registry.lookup("no-such-token") is None
+
+    def test_lookup_or_default_falls_back(self):
+        default = AgentPolicy.from_token("default", "d", access_mode="readonly")
+        registry = AgentPolicyRegistry(default_policy=default)
+        result = registry.lookup_or_default(None)
+        assert result is default
+
+    def test_lookup_or_default_no_default_returns_none(self):
+        registry = AgentPolicyRegistry()
+        assert registry.lookup_or_default(None) is None
+
+    def test_len(self):
+        registry = AgentPolicyRegistry()
+        registry.register(AgentPolicy.from_token("a", "t1"))
+        registry.register(AgentPolicy.from_token("b", "t2"))
+        assert len(registry) == 2
+
+
+# ---------------------------------------------------------------------------
+# policy_loader — YAML
+# ---------------------------------------------------------------------------
+
+YAML_CONTENT = textwrap.dedent("""
+    agents:
+      - name: reporting-bot
+        token: "rpt-abc123"
+        access_mode: readonly
+        allowed_schemas: ["analytics", "public"]
+        allowed_tools: ["execute_sql", "list_objects"]
+        audit: true
+
+      - name: migration-agent
+        token: "mig-xyz789"
+        access_mode: unrestricted
+        allowed_schemas: ["*"]
+        allowed_tools: ["*"]
+        audit: false
+
+    default_access_mode: readonly
+""")
+
+
+class TestPolicyLoader:
+    def test_load_yaml(self, tmp_path: Path):
+        policy_file = tmp_path / "agents.yaml"
+        policy_file.write_text(YAML_CONTENT)
+
+        registry = load_policies_from_yaml(policy_file)
+        assert len(registry) == 2
+
+        rpt = registry.lookup("rpt-abc123")
+        assert rpt is not None
+        assert rpt.name == "reporting-bot"
+        assert rpt.access_mode == AccessMode.READONLY
+        assert "analytics" in rpt.allowed_schemas
+        assert rpt.audit is True
+
+        mig = registry.lookup("mig-xyz789")
+        assert mig is not None
+        assert mig.access_mode == AccessMode.UNRESTRICTED
+        assert mig.audit is False
+
+    def test_yaml_default_policy(self, tmp_path: Path):
+        policy_file = tmp_path / "agents.yaml"
+        policy_file.write_text(YAML_CONTENT)
+        registry = load_policies_from_yaml(policy_file)
+        assert registry.default_policy is not None
+        assert registry.default_policy.access_mode == AccessMode.READONLY
+
+    def test_yaml_missing_required_field(self, tmp_path: Path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("agents:\n  - name: bot\n")
+        with pytest.raises(ValueError, match="missing required fields"):
+            load_policies_from_yaml(bad)
+
+    def test_yaml_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_policies_from_yaml("/no/such/file.yaml")
+
+    def test_load_from_env(self, monkeypatch):
+        data = [{"name": "env-bot", "token": "env-tok", "access_mode": "restricted"}]
+        monkeypatch.setenv("AGENT_POLICIES_JSON", json.dumps(data))
+        registry = load_policies_from_env("AGENT_POLICIES_JSON")
+        assert registry is not None
+        assert len(registry) == 1
+        p = registry.lookup("env-tok")
+        assert p is not None
+        assert p.access_mode == AccessMode.RESTRICTED
+
+    def test_load_from_env_not_set_returns_none(self, monkeypatch):
+        monkeypatch.delenv("AGENT_POLICIES_JSON", raising=False)
+        assert load_policies_from_env("AGENT_POLICIES_JSON") is None
+
+
+# ---------------------------------------------------------------------------
+# RbacSqlDriver
+# ---------------------------------------------------------------------------
+
+class TestRbacSqlDriver:
+    def _make_driver(self, **policy_kwargs):
+        base = MagicMock()
+        base.execute_query = AsyncMock(return_value=[])
+        policy = AgentPolicy.from_token(
+            name="test-agent",
+            token="test-token",
+            **policy_kwargs,
+        )
+        driver = RbacSqlDriver(sql_driver=base, policy=policy)
+        # Bypass inner driver wrapping for unit tests
+        driver._effective_driver = base
+        return driver, base
+
+    @pytest.mark.asyncio
+    async def test_allowed_tool_passes(self):
+        driver, base = self._make_driver(
+            access_mode="unrestricted",
+            allowed_tools=["execute_sql"],
+        )
+        await driver.execute_query("SELECT 1", tool_name="execute_sql")
+        base.execute_query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_blocked_tool_raises(self):
+        driver, _ = self._make_driver(
+            access_mode="unrestricted",
+            allowed_tools=["execute_sql"],
+        )
+        with pytest.raises(ToolViolationError):
+            await driver.execute_query("SELECT 1", tool_name="run_health_check")
+
+    @pytest.mark.asyncio
+    async def test_schema_violation_raises(self):
+        driver, _ = self._make_driver(
+            access_mode="unrestricted",
+            allowed_schemas=["public"],
+        )
+        with pytest.raises(SchemaViolationError):
+            await driver.execute_query("SELECT * FROM secrets.passwords")
+
+    @pytest.mark.asyncio
+    async def test_allowed_schema_passes(self):
+        driver, base = self._make_driver(
+            access_mode="unrestricted",
+            allowed_schemas=["public"],
+        )
+        await driver.execute_query("SELECT * FROM public.users")
+        base.execute_query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_wildcard_schema_allows_all(self):
+        driver, base = self._make_driver(
+            access_mode="unrestricted",
+            allowed_schemas=["*"],
+        )
+        await driver.execute_query("SELECT * FROM any_schema.any_table")
+        base.execute_query.assert_called_once()


### PR DESCRIPTION
## Problem

Current access modes (`unrestricted` / `restricted` / `readonly`) are **server-wide**: every client connecting to the same server instance gets the same level of access.

This is a problem when multiple AI agents with different trust levels connect to the same server:
- A read-only reporting bot needs `readonly` access to `analytics` schema only
- A schema inspector needs `restricted` access to all schemas
- A privileged migration agent needs `unrestricted` access

Today this requires running **three separate server instances** — one per access level.

## Solution

This PR adds a YAML-driven **per-agent policy engine** where each agent is identified by a bearer token (`X-Agent-Token` header) and gets its own fine-grained policy:

```yaml
agents:
  - name: reporting-bot
    token: "rpt-abc123"
    access_mode: readonly
    allowed_schemas: ["analytics", "public"]
    allowed_tools: ["execute_sql", "list_objects"]
    audit: true

  - name: migration-agent
    token: "mig-xyz789"
    access_mode: unrestricted
    allowed_schemas: ["*"]
    allowed_tools: ["*"]
    audit: true

default_access_mode: readonly
```

Start the server:
```bash
postgres-mcp "postgresql://user:pass@host/db" --agent-policies ./agents.yaml
```

## Architecture

The implementation follows the same **decorator pattern** used by `SafeSqlDriver` and `ReadOnlySqlDriver`:

```
MCP Request
  └── X-Agent-Token header
        └── AgentPolicyRegistry.lookup(token)
              └── RbacSqlDriver(base_driver, policy)
                    ├── ToolViolationError  (if tool not allowed)
                    ├── SchemaViolationError (if schema not allowed)
                    ├── Delegates to SafeSqlDriver  (restricted mode)
                    ├── Delegates to ReadOnlySqlDriver (readonly mode)
                    └── Delegates to SqlDriver (unrestricted mode)
```

## New Files

| File | Description |
|---|---|
| `src/postgres_mcp/rbac/__init__.py` | Module exports |
| `src/postgres_mcp/rbac/agent_policy.py` | `AgentPolicy` dataclass + `AgentPolicyRegistry` |
| `src/postgres_mcp/rbac/policy_loader.py` | YAML + JSON env var loader |
| `src/postgres_mcp/rbac/rbac_sql_driver.py` | `RbacSqlDriver` decorator |
| `tests/unit/rbac/test_agent_policy.py` | 18 unit tests |
| `docs/agent-policies.md` | Full usage documentation |

## Security Design

- **Tokens are SHA-256 hashed** at load time — plaintext secrets never live in memory after startup
- **`hmac.compare_digest`** prevents timing attacks during token comparison
- **Schema guards** reject queries referencing unlisted schemas before they reach the database
- **Tool guards** reject disallowed MCP tool calls before any SQL is executed
- **Audit logging** emits structured JSON per query for full observability
- Per-agent policies **layer on top of** the server's global `--access-mode` (stricter wins)

## Tests

18 unit tests covering:
- `AgentPolicy`: token hashing, `matches_token` timing-safe comparison, schema/tool permission checks
- `AgentPolicyRegistry`: register/lookup, default policy fallback
- `policy_loader`: YAML loading, env var loading, validation errors
- `RbacSqlDriver`: tool violation, schema violation, wildcard bypass, audit log emission

```
tests/unit/rbac/test_agent_policy.py::TestAgentPolicy::test_from_token_defaults PASSED
tests/unit/rbac/test_agent_policy.py::TestAgentPolicy::test_token_is_hashed PASSED
tests/unit/rbac/test_agent_policy.py::TestAgentPolicy::test_matches_token_correct PASSED
... (18 tests total)
```

## Relationship to Other PRs

- Complements #148 (`readonly` access mode) — `RbacSqlDriver` uses `ReadOnlySqlDriver` when available
- Compatible with #154 (`--allow-function-prefix`) — per-agent policies can use `restricted` mode with custom function prefixes
- Addresses a use case not covered by any existing PR: **different policies for different agents on the same server**

## Docker / Kubernetes Support

For deployments where mounting a YAML file is inconvenient:

```bash
export AGENT_POLICIES_JSON='[{"name":"bot","token":"tok1","access_mode":"readonly"}]'
postgres-mcp "postgresql://user:pass@host/db"
```
