### PR TITLE
Connect to database lazily with configurable idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,42 @@ Postgres MCP Pro supports multiple *access modes* to give you control over the o
 To use restricted mode, replace `--access-mode=unrestricted` with `--access-mode=restricted` in the configuration examples above.
 
 
+##### Idle Connection Timeout
+
+Postgres MCP Pro connects to the database **lazily** — no connection is opened when the server starts, only on the first tool call that needs the database. Once a connection has been idle for a while it is reaped, so a server you configure but don't use holds zero Postgres connections. This is helpful when you define many database configs and don't want every server holding an open connection from session start.
+
+The idle timeout defaults to **300 seconds** and is configurable with the `--max-idle` flag (in seconds), or the `DATABASE_MAX_IDLE` environment variable. The flag takes precedence over the environment variable, and invalid values (non-numeric, zero, or negative) fall back to the default.
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "uvx",
+      "args": [
+        "postgres-mcp",
+        "--access-mode=unrestricted",
+        "--max-idle=120"
+      ],
+      "env": {
+        "DATABASE_URI": "postgresql://username:password@localhost:5432/dbname"
+      }
+    }
+  }
+}
+```
+
+Equivalently, using the environment variable instead of the flag:
+
+```json
+      "env": {
+        "DATABASE_URI": "postgresql://username:password@localhost:5432/dbname",
+        "DATABASE_MAX_IDLE": "120"
+      }
+```
+
+A reaped connection is re-established transparently on the next tool call, restarting the idle timer. Lower values release connections faster (good for many-database setups); higher values keep connections warm to avoid reconnect latency on frequently-used databases.
+
+
 #### Other MCP Clients
 
 Many MCP clients have similar configuration files to Claude Desktop, and you can adapt the examples above to work with the client of your choice.

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -31,7 +31,6 @@ from .sql import DbConnPool
 from .sql import SafeSqlDriver
 from .sql import SqlDriver
 from .sql import check_hypopg_installation_status
-from .sql import obfuscate_password
 from .top_queries import TopQueriesCalc
 
 # Initialize FastMCP with default settings
@@ -596,8 +595,32 @@ async def main():
         default=8000,
         help="Port for streamable HTTP server (default: 8000)",
     )
+    parser.add_argument(
+        "--max-idle",
+        type=int,
+        default=None,
+        help="Seconds an unused database connection stays open before it is reaped "
+        f"(default: {DbConnPool.DEFAULT_MAX_IDLE}). Can also be set via the DATABASE_MAX_IDLE "
+        "environment variable. Useful when defining many database configs so idle servers "
+        "release their connections.",
+    )
 
     args = parser.parse_args()
+
+    # Configure the idle-connection timeout (CLI flag takes precedence over env var).
+    # Invalid values are rejected by DbConnPool.max_idle, which falls back to the default.
+    max_idle_env = os.environ.get("DATABASE_MAX_IDLE")
+    if args.max_idle is not None:
+        db_connection.max_idle = args.max_idle
+    elif max_idle_env is not None:
+        try:
+            db_connection.max_idle = int(max_idle_env)
+        except ValueError:
+            logger.warning(
+                "Ignoring non-numeric DATABASE_MAX_IDLE=%r; using default of %s seconds",
+                max_idle_env,
+                DbConnPool.DEFAULT_MAX_IDLE,
+            )
 
     # Store the access mode in the global variable
     global current_access_mode
@@ -633,17 +656,13 @@ async def main():
             "Error: No database URL provided. Please specify via 'DATABASE_URI' environment variable or command-line argument.",
         )
 
-    # Initialize database connection pool
-    try:
-        await db_connection.pool_connect(database_url)
-        logger.info("Successfully connected to database and initialized connection pool")
-    except Exception as e:
-        logger.warning(
-            f"Could not connect to database: {obfuscate_password(str(e))}",
-        )
-        logger.warning(
-            "The MCP server will start but database operations will fail until a valid connection is established.",
-        )
+    # Store the database URL but do NOT connect yet. The connection pool is
+    # established lazily on the first tool call that needs it (see
+    # SqlDriver.execute_query -> DbConnPool.pool_connect). This lets you define
+    # many database MCP configs without each server holding an open Postgres
+    # connection from session start.
+    db_connection.connection_url = database_url
+    logger.info("Database URL configured; connection will be established on first use (lazy)")
 
     # Set up proper shutdown handling
     try:

--- a/src/postgres_mcp/sql/sql_driver.py
+++ b/src/postgres_mcp/sql/sql_driver.py
@@ -62,11 +62,31 @@ def obfuscate_password(text: str | None) -> str | None:
 class DbConnPool:
     """Database connection manager using psycopg's connection pool."""
 
-    def __init__(self, connection_url: Optional[str] = None):
+    # Default seconds an unused connection stays open before being reaped.
+    DEFAULT_MAX_IDLE = 300
+
+    def __init__(self, connection_url: Optional[str] = None, max_idle: int = DEFAULT_MAX_IDLE):
         self.connection_url = connection_url
+        self.max_idle = max_idle  # validated via the property setter
         self.pool: AsyncConnectionPool | None = None
         self._is_valid = False
         self._last_error = None
+
+    @property
+    def max_idle(self) -> int:
+        """Seconds an unused connection stays open before being reaped."""
+        return self._max_idle
+
+    @max_idle.setter
+    def max_idle(self, value: Optional[int]) -> None:
+        # psycopg_pool does not range-check max_idle, so a non-positive value would
+        # schedule a degenerate (zero/negative-interval) pool-shrink task. Reject it
+        # and fall back to the default instead.
+        if value is None or value <= 0:
+            logger.warning("Ignoring invalid max_idle=%r; using default of %s seconds", value, self.DEFAULT_MAX_IDLE)
+            self._max_idle = self.DEFAULT_MAX_IDLE
+        else:
+            self._max_idle = value
 
     async def pool_connect(self, connection_url: Optional[str] = None) -> AsyncConnectionPool:
         """Initialize connection pool with retry logic."""
@@ -85,11 +105,17 @@ class DbConnPool:
         await self.close()
 
         try:
-            # Configure connection pool with appropriate settings
+            # Configure connection pool with appropriate settings.
+            # min_size=0 so an idle pool holds NO open connections; combined with
+            # lazy pool_connect (called on first tool use) this means a server that
+            # is configured but never used keeps zero Postgres connections.
+            # max_idle reaps connections after a period of inactivity, so a database
+            # that is touched once and then left alone releases its connection.
             self.pool = AsyncConnectionPool(
                 conninfo=url,
-                min_size=1,
+                min_size=0,
                 max_size=5,
+                max_idle=self.max_idle,  # close idle connections after this many seconds
                 open=False,  # Don't connect immediately, let's do it explicitly
             )
 


### PR DESCRIPTION
## Summary

Establish the connection pool on first tool use instead of at server startup, and let idle connections be reaped. This makes it practical to define many database MCP configs without every server holding an open Postgres connection from session start.

## Motivation

When a user defines a large number of `postgres-mcp` servers (one per database), the previous behavior opened and held a live Postgres connection for every configured server as soon as the MCP client started — even for databases that are never queried in a session. That hogs connection slots on the database side.

## Changes

- **`server.py`**: store the database URL without connecting eagerly. The lazy path already present in `SqlDriver.execute_query` opens the pool on first use, so the startup `pool_connect` call was redundant.
- **`sql/sql_driver.py`**: the pool now uses `min_size=0` with a `max_idle` reaper, so an unused/idle server releases its connection(s) back to zero.
- **Configurable idle timeout**: new `--max-idle` flag and `DATABASE_MAX_IDLE` env var (default 300s). Invalid values (non-numeric, zero, negative) fall back to the default via a validating `max_idle` property — a single chokepoint covering the constructor, CLI flag, and env var.
- **README**: documents lazy connections and the idle timeout with config examples.

## Behavior

- No DB connection is opened at server start; the first tool call that needs the database establishes it.
- A connection idle past `max_idle` is reaped and transparently re-established on the next query (the idle timer restarts per connection).
- The happy path (default 300s) is unchanged.

## Testing

All existing unit tests pass (`tests/unit/test_transport.py`, `test_access_mode.py`, `tests/unit/sql/`), and the `max_idle` validation/fallback paths were verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)