### PR TITLE
Loosen pglast pin to a compatible range (>=7.11,<8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "mcp[cli]>=1.25.0",
     "psycopg[binary]>=3.3.2",
     "humanize>=4.15.0",
-    "pglast==7.11",
+    "pglast>=7.11,<8",
     "attrs>=25.4.0",
     "psycopg-pool>=3.3.0",
     "instructor>=1.14.4",


### PR DESCRIPTION
## What
Loosen the exact `pglast==7.11` pin in `pyproject.toml` to a compatible range `pglast>=7.11,<8`.

## Why
`pglast` bundles a compiled libpg_query C extension, so each release only ships wheels for the CPython versions available at *its* release time. Exact-pinning it therefore makes `postgres-mcp` break on any CPython newer than the pinned pglast's wheels — even when `requires-python` already allows that interpreter.

This is biting users today: the current PyPI release (`postgres-mcp 0.3.0`) pins `pglast==7.2.0`, which has **no cp314 wheel**, so `uvx postgres-mcp` / `pip install postgres-mcp` **fails to build on Python 3.14** despite `requires-python = ">=3.12"`. The only workaround right now is forcing a newer pglast via a uv `--overrides` file.

`main` already moved to `pglast==7.11` (which *does* ship a cp314 wheel), so a release would fix the immediate 3.14 break. Loosening the pin to `>=7.11,<8` additionally future-proofs it: pip/uv resolve the newest 7.x automatically (currently 7.15), picking up new-CPython wheels and patch fixes without another manual pin bump, while staying inside the pglast 7.x (PG16 parser) major.

## Verification
`pglast>=7.11,<8` resolves to 7.15 under Python 3.14 and installs from a prebuilt cp314 wheel (no source build); `postgres-mcp --help` runs cleanly. Older interpreters resolve the same way (all covered by wheels).
