### PR TITLE
Constrain mcp[cli] to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "PostgreSQL Tuning and Analysis Tool"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.25.0",
+    "mcp[cli]>=1.25.0,<2",
     "psycopg[binary]>=3.3.2",
     "humanize>=4.15.0",
     "pglast==7.11",

--- a/uv.lock
+++ b/uv.lock
@@ -897,7 +897,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=25.4.0" },
     { name = "humanize", specifier = ">=4.15.0" },
     { name = "instructor", specifier = ">=1.14.4" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.25.0,<2" },
     { name = "pglast", specifier = "==7.11" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.2" },
     { name = "psycopg-pool", specifier = ">=3.3.0" },


### PR DESCRIPTION
Fixes #187.

## Problem

`mcp[cli]>=1.25.0` has no upper bound, so a fresh resolve picks up `mcp` 2.0.0. That release removed `mcp.server.fastmcp`, which `postgres_mcp/server.py` imports, so the package fails at import time before it can open a connection:

```
File "postgres_mcp/server.py", line 15, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

This hits anyone installing from published metadata - `uvx postgres-mcp`, `pip install postgres-mcp`, `uv tool install`. CI does not catch it because `uv sync` resolves from `uv.lock`, which already held `mcp` 1.25.0, so the failure only ever reaches end users.

MCP clients surface this as an opaque transport error rather than an import failure, since the server process exits during startup. In Claude Code it appears as `MCP error -32000: Connection closed`, which sends people looking at their database connectivity instead of their dependency tree.

## Fix

Add the upper bound: `mcp[cli]>=1.25.0,<2`.

`uv.lock` is regenerated, but only the recorded `requires-dist` specifier changes - the locked `mcp` version stays 1.25.0, so there is no dependency churn for existing environments.

## Verification

`uv sync`, `uv run ruff format --check .`, `uv run ruff check .` and `uv run pyright` all pass (pyright: 0 errors, 0 warnings).

Installing the project into a clean venv without the lockfile - the path `uvx` and `pip` take - now resolves `mcp` 1.29.0, the newest 1.x, and `from mcp.server.fastmcp import FastMCP` succeeds. The same install before this change resolved `mcp` 2.0.0 and raised the `ModuleNotFoundError` above.
