### PR TITLE
Change default access mode to RESTRICTED and warn on UNRESTRICTED startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ Replace `postgresql://...` with your [Postgres database connection URI](https://
 ##### Access Mode
 
 Postgres MCP Pro supports multiple *access modes* to give you control over the operations that the AI agent can perform on the database:
-- **Unrestricted Mode**: Allows full read/write access to modify data and schema. It is suitable for development environments.
-- **Restricted Mode**: Limits operations to read-only transactions and imposes constraints on resource utilization (presently only execution time). It is suitable for production environments.
+- **Restricted Mode (default)**: Limits operations to read-only transactions and imposes constraints on resource utilization (presently only execution time). It is suitable for production environments.
+- **Unrestricted Mode**: Allows full read/write access to modify data and schema. It is suitable for development environments. Starting with unrestricted mode active prints a startup warning, because any content the agent reads (web pages, tickets, emails) can carry prompt-injection payloads that reach `execute_sql` unfiltered.
 
-To use restricted mode, replace `--access-mode=unrestricted` with `--access-mode=restricted` in the configuration examples above.
+Restricted mode is the default. To allow write operations, add `--access-mode=unrestricted` to the configuration examples above explicitly.
 
 
 #### Other MCP Clients

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ Postgres MCP Pro supports multiple *access modes* to give you control over the o
 
 Restricted mode is the default. To allow write operations, add `--access-mode=unrestricted` to the configuration examples above explicitly.
 
+> **Breaking change:** The default access mode is now RESTRICTED (read-only).
+> Deployments that relied on the implicit UNRESTRICTED default must pass
+> `--access-mode=unrestricted` explicitly after upgrading. Unrestricted startup
+> prints a warning explaining the prompt-injection risk.
+
 
 #### Other MCP Clients
 

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -55,7 +55,7 @@ class AccessMode(str, Enum):
 
 # Global variables
 db_connection = DbConnPool()
-current_access_mode = AccessMode.UNRESTRICTED
+current_access_mode = AccessMode.RESTRICTED
 shutdown_in_progress = False
 
 
@@ -562,8 +562,8 @@ async def main():
         "--access-mode",
         type=str,
         choices=[mode.value for mode in AccessMode],
-        default=AccessMode.UNRESTRICTED.value,
-        help="Set SQL access mode: unrestricted (unrestricted) or restricted (read-only with protections)",
+        default=AccessMode.RESTRICTED.value,
+        help="Set SQL access mode: restricted (read-only with protections, default) or unrestricted (full read/write access)",
     )
     parser.add_argument(
         "--transport",
@@ -602,6 +602,17 @@ async def main():
     # Store the access mode in the global variable
     global current_access_mode
     current_access_mode = AccessMode(args.access_mode)
+
+    if current_access_mode == AccessMode.UNRESTRICTED:
+        logger.warning(
+            "⚠️  UNRESTRICTED mode is active: the LLM can execute ANY SQL, "
+            "including destructive statements (DROP/DELETE/ALTER). "
+            "Content read by the agent (pages, tickets, emails) can carry "
+            "prompt-injection payloads that reach execute_sql unfiltered. "
+            "Use UNRESTRICTED only for trusted development databases. "
+            "Omit --access-mode or pass '--access-mode restricted' for "
+            "read-only protection."
+        )
 
     # Add the query tool with a description and annotations appropriate to the access mode
     if current_access_mode == AccessMode.UNRESTRICTED:

--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -49,8 +49,8 @@ logger = logging.getLogger(__name__)
 class AccessMode(str, Enum):
     """SQL access modes for the server."""
 
+    RESTRICTED = "restricted"  # Read-only with safety features (default)
     UNRESTRICTED = "unrestricted"  # Unrestricted access
-    RESTRICTED = "restricted"  # Read-only with safety features
 
 
 # Global variables
@@ -605,13 +605,18 @@ async def main():
 
     if current_access_mode == AccessMode.UNRESTRICTED:
         logger.warning(
-            "⚠️  UNRESTRICTED mode is active: the LLM can execute ANY SQL, "
+            "[SECURITY] UNRESTRICTED mode is active: the LLM can execute ANY SQL, "
             "including destructive statements (DROP/DELETE/ALTER). "
             "Content read by the agent (pages, tickets, emails) can carry "
             "prompt-injection payloads that reach execute_sql unfiltered. "
             "Use UNRESTRICTED only for trusted development databases. "
             "Omit --access-mode or pass '--access-mode restricted' for "
             "read-only protection."
+        )
+    else:
+        logger.info(
+            "Running in restricted (read-only) mode. "
+            "Pass --access-mode=unrestricted for write access."
         )
 
     # Add the query tool with a description and annotations appropriate to the access mode

--- a/tests/unit/test_access_mode.py
+++ b/tests/unit/test_access_mode.py
@@ -112,3 +112,47 @@ async def test_command_line_parsing():
         # Restore original values
         sys.argv = original_argv
         asyncio.run = original_run
+
+
+@pytest.mark.asyncio
+async def test_command_line_parsing_default_restricted():
+    """Default (no --access-mode) must resolve to RESTRICTED (security default, PR #193)."""
+    import sys
+
+    from postgres_mcp.server import main
+
+    original_argv = sys.argv
+    original_run = asyncio.run
+
+    try:
+        # No --access-mode flag at all
+        sys.argv = [
+            "postgres_mcp",
+            "postgresql://user:password@localhost/db",
+        ]
+        asyncio.run = AsyncMock()
+
+        with (
+            patch("postgres_mcp.server.current_access_mode", AccessMode.UNRESTRICTED),
+            patch("postgres_mcp.server.db_connection.pool_connect", AsyncMock()),
+            patch("postgres_mcp.server.mcp.run_stdio_async", AsyncMock()),
+            patch("postgres_mcp.server.shutdown", AsyncMock()),
+        ):
+            # Reset the current_access_mode to UNRESTRICTED
+            import postgres_mcp.server
+
+            postgres_mcp.server.current_access_mode = AccessMode.UNRESTRICTED
+
+            # Run main (partially mocked to avoid actual connection)
+            try:
+                await main()
+            except Exception:
+                pass
+
+            # The security default must win when the flag is omitted
+            assert postgres_mcp.server.current_access_mode == AccessMode.RESTRICTED
+
+    finally:
+        # Restore original values
+        sys.argv = original_argv
+        asyncio.run = original_run


### PR DESCRIPTION
## Motivation

Following up on #164: the server currently defaults to `UNRESTRICTED`, which
exposes `execute_sql` with full write capabilities to the LLM. Because the
`sql` parameter is passed through without filtering, any prompt-injection
payload in content the agent reads (web pages, Confluence, emails) can reach
the database verbatim — a cross-tool injection path from one poisoned page to
`DROP TABLE` / `DELETE` on a production database.

The existing `SafeSqlDriver` (`force_readonly=True`) already solves this well;
it just isn't the default.

## Changes

- **`--access-mode` now defaults to `restricted`** (module-level default
  aligned in `server.py`).
- **Explicit `--access-mode unrestricted` prints a startup warning** covering
  destructive SQL and the prompt-injection risk, and points to the restricted
  mode.
- **README "Access Mode" section updated** to document restricted as the
  default (the configuration examples already pass `--access-mode=unrestricted`
  explicitly, so they keep working unchanged).

## Backwards compatibility

This is a deliberate behavior change for users who relied on the implicit
default. Users who start the server with `--access-mode=unrestricted` (as in
all README examples) see no functional change beyond the new startup warning.

## Tests

- `pytest tests/unit` (Windows, Python 3.12): **167 passed, 24 skipped
  (DB-dependent), 1 xfailed** — including all access-mode tests and the
  Python-3.12-only `tests/unit/index/test_dta_calc.py` (PEP 701).
- Earlier run (Windows, Python 3.11): 134 passed, 24 skipped, 1 xfailed
  (same suite minus the 3.12-only file).
- Existing mode tests pass the flag explicitly and are unaffected.

## Out of scope (happy to follow up)

- Recommendation 2 from #164 (DDL statement allowlist in UNRESTRICTED mode,
  e.g. blocking DROP/ALTER/TRUNCATE unless explicitly enabled) deserves its
  own PR with a proper design discussion.

Static analysis only; no live databases were tested.
