### PR TITLE
fix: stop pool churn and pool leaks on query errors (#98)

### DIFF
--- a/src/postgres_mcp/sql/sql_driver.py
+++ b/src/postgres_mcp/sql/sql_driver.py
@@ -1,5 +1,6 @@
 """SQL driver adapter for PostgreSQL connections."""
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -10,11 +11,27 @@ from typing import Optional
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
+import psycopg
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 from typing_extensions import LiteralString
 
 logger = logging.getLogger(__name__)
+
+
+def _invalidates_pool(e: BaseException) -> bool:
+    """Whether an error means the connection pool itself is unusable.
+
+    Query-level failures (bad SQL, constraint violations, ...) and statement
+    timeouts leave the underlying connections healthy, so the pool must
+    survive them. Only connection-level errors (server gone away, broken
+    socket, pool timeout/closed — all OperationalError or InterfaceError)
+    warrant rebuilding the pool.
+    """
+    if isinstance(e, psycopg.errors.QueryCanceled):
+        # Statement timeout / cancellation: the connection is fine.
+        return False
+    return isinstance(e, (psycopg.OperationalError, psycopg.InterfaceError))
 
 
 def obfuscate_password(text: str | None) -> str | None:
@@ -67,6 +84,7 @@ class DbConnPool:
         self.pool: AsyncConnectionPool | None = None
         self._is_valid = False
         self._last_error = None
+        self._connect_lock = asyncio.Lock()
 
     async def pool_connect(self, connection_url: Optional[str] = None) -> AsyncConnectionPool:
         """Initialize connection pool with retry logic."""
@@ -74,44 +92,60 @@ class DbConnPool:
         if self.pool and self._is_valid:
             return self.pool
 
-        url = connection_url or self.connection_url
-        self.connection_url = url
-        if not url:
-            self._is_valid = False
-            self._last_error = "Database connection URL not provided"
-            raise ValueError(self._last_error)
+        # Serialize pool (re)creation. Without the lock, concurrent callers
+        # that each observed an invalid pool would each build an
+        # AsyncConnectionPool and assign it to self.pool; every overwritten
+        # pool is left open forever — leaking its connections and worker
+        # tasks — and callers still holding a pool that a later winner
+        # closed fail with "the pool 'pool-N' is closed".
+        async with self._connect_lock:
+            # Re-check under the lock: another task may have already rebuilt
+            # the pool while we were waiting.
+            if self.pool and self._is_valid:
+                return self.pool
 
-        # Close any existing pool before creating a new one
-        await self.close()
+            url = connection_url or self.connection_url
+            self.connection_url = url
+            if not url:
+                self._is_valid = False
+                self._last_error = "Database connection URL not provided"
+                raise ValueError(self._last_error)
 
-        try:
-            # Configure connection pool with appropriate settings
-            self.pool = AsyncConnectionPool(
-                conninfo=url,
-                min_size=1,
-                max_size=5,
-                open=False,  # Don't connect immediately, let's do it explicitly
-            )
-
-            # Open the pool explicitly
-            await self.pool.open()
-
-            # Test the connection pool by executing a simple query
-            async with self.pool.connection() as conn:
-                async with conn.cursor() as cursor:
-                    await cursor.execute("SELECT 1")
-
-            self._is_valid = True
-            self._last_error = None
-            return self.pool
-        except Exception as e:
-            self._is_valid = False
-            self._last_error = str(e)
-
-            # Clean up failed pool
+            # Close any existing pool before creating a new one
             await self.close()
 
-            raise ValueError(f"Connection attempt failed: {obfuscate_password(str(e))}") from e
+            try:
+                # Configure connection pool with appropriate settings
+                self.pool = AsyncConnectionPool(
+                    conninfo=url,
+                    min_size=1,
+                    max_size=5,
+                    open=False,  # Don't connect immediately, let's do it explicitly
+                    # Validate connections on checkout so ones broken while
+                    # idle (server restart, idle timeout) are discarded and
+                    # replaced instead of surfacing as query errors.
+                    check=AsyncConnectionPool.check_connection,
+                )
+
+                # Open the pool explicitly
+                await self.pool.open()
+
+                # Test the connection pool by executing a simple query
+                async with self.pool.connection() as conn:
+                    async with conn.cursor() as cursor:
+                        await cursor.execute("SELECT 1")
+
+                self._is_valid = True
+                self._last_error = None
+                return self.pool
+            except Exception as e:
+                self._is_valid = False
+                self._last_error = str(e)
+
+                # Clean up failed pool
+                await self.close()
+
+                raise ValueError(f"Connection attempt failed: {obfuscate_password(str(e))}") from e
 
     async def close(self) -> None:
         """Close the connection pool."""
@@ -212,10 +246,15 @@ class SqlDriver:
                 # Direct connection approach
                 return await self._execute_with_connection(self.conn, query, params, force_readonly=force_readonly)
         except Exception as e:
-            # Mark pool as invalid if there was a connection issue
+            # Mark pool as invalid only on connection-level errors. Doing it
+            # for every exception meant any bad SQL statement poisoned the
+            # shared pool, and the next call tore it down and built a new
+            # one — the pool churn and "the pool 'pool-N' is closed" errors
+            # of issue #98.
             if self.conn and self.is_pool:
-                self.conn._is_valid = False  # type: ignore
-                self.conn._last_error = str(e)  # type: ignore
+                if _invalidates_pool(e):
+                    self.conn._is_valid = False  # type: ignore
+                    self.conn._last_error = str(e)  # type: ignore
             elif self.conn and not self.is_pool:
                 self.conn = None
 

--- a/tests/unit/sql/test_db_conn_pool.py
+++ b/tests/unit/sql/test_db_conn_pool.py
@@ -212,3 +212,62 @@ async def test_connection_url_property():
     # Change the URL
     db_pool.connection_url = "postgresql://newuser:newpass@otherhost/otherdb"
     assert db_pool.connection_url == "postgresql://newuser:newpass@otherhost/otherdb"
+
+
+def _wired_pool_mock():
+    """A pool mock supporting `async with pool.connection()` -> `async with conn.cursor()`.
+
+    Built with mock's native async-context-manager support: `.cursor` and
+    `.connection` are sync callables returning MagicMocks, whose `__aenter__`
+    (an AsyncMock on MagicMock) yields the next object.
+    """
+    import asyncio
+
+    cursor_cm = MagicMock()
+    cursor_cm.__aenter__.return_value = AsyncMock()
+
+    connection = MagicMock()
+    connection.cursor = MagicMock(return_value=cursor_cm)
+
+    conn_cm = MagicMock()
+    conn_cm.__aenter__.return_value = connection
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    # pool.open() must actually yield to the event loop so concurrent
+    # pool_connect calls interleave the way they do against a real database.
+    async def slow_open():
+        await asyncio.sleep(0)
+
+    pool.open = AsyncMock(side_effect=slow_open)
+    pool.close = AsyncMock()
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pool_connect_creates_single_pool():
+    """Concurrent callers reconnecting must share one pool (issue #98).
+
+    Without serialization, every caller that observes an invalid pool builds
+    its own AsyncConnectionPool; all but the last-assigned pool are leaked
+    (never closed, still holding connections and worker tasks), and callers
+    holding a pool a later winner closed fail with "the pool ... is closed".
+    """
+    import asyncio
+
+    created_pools = []
+
+    def make_pool(*args, **kwargs):
+        pool = _wired_pool_mock()
+        created_pools.append(pool)
+        return pool
+
+    with patch("postgres_mcp.sql.sql_driver.AsyncConnectionPool", side_effect=make_pool):
+        db_pool = DbConnPool("postgresql://user:pass@localhost/db")
+        pools = await asyncio.gather(*(db_pool.pool_connect() for _ in range(10)))
+
+    assert len(created_pools) == 1
+    assert all(pool is created_pools[0] for pool in pools)
+    assert db_pool.is_valid
+    created_pools[0].close.assert_not_called()

--- a/tests/unit/sql/test_sql_driver.py
+++ b/tests/unit/sql/test_sql_driver.py
@@ -365,3 +365,70 @@ async def test_engine_url_connection():
         # Verify driver state
         assert driver.is_pool is True
         assert driver.conn is not None
+
+
+def _driver_with_failing_cursor(error):
+    """A SqlDriver on a mock DbConnPool whose cursor raises `error` on execute."""
+    cursor = AsyncMock()
+    cursor.execute.side_effect = error
+
+    cursor_cm = MagicMock()
+    cursor_cm.__aenter__.return_value = cursor
+
+    connection = MagicMock()
+    connection.cursor = MagicMock(return_value=cursor_cm)
+
+    conn_cm = MagicMock()
+    conn_cm.__aenter__.return_value = connection
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    db_pool = MagicMock(spec=DbConnPool)
+    db_pool.pool_connect.return_value = pool
+    db_pool._is_valid = True
+
+    return SqlDriver(conn=db_pool), db_pool
+
+
+@pytest.mark.asyncio
+async def test_query_error_does_not_invalidate_pool():
+    """Bad SQL must not poison the shared pool (issue #98).
+
+    Marking the pool invalid on query-level errors made the next call tear
+    the pool down and rebuild it, churning pools on every malformed query.
+    """
+    import psycopg
+
+    driver, db_pool = _driver_with_failing_cursor(psycopg.errors.UndefinedTable('relation "missing" does not exist'))
+
+    with pytest.raises(psycopg.errors.UndefinedTable):
+        await driver.execute_query("SELECT * FROM missing")
+
+    assert db_pool._is_valid is True
+
+
+@pytest.mark.asyncio
+async def test_statement_timeout_does_not_invalidate_pool():
+    """A canceled statement leaves the connection healthy; keep the pool."""
+    import psycopg
+
+    driver, db_pool = _driver_with_failing_cursor(psycopg.errors.QueryCanceled("canceling statement due to statement timeout"))
+
+    with pytest.raises(psycopg.errors.QueryCanceled):
+        await driver.execute_query("SELECT pg_sleep(60)")
+
+    assert db_pool._is_valid is True
+
+
+@pytest.mark.asyncio
+async def test_operational_error_invalidates_pool():
+    """A connection-level failure must still mark the pool for rebuild."""
+    import psycopg
+
+    driver, db_pool = _driver_with_failing_cursor(psycopg.OperationalError("server closed the connection unexpectedly"))
+
+    with pytest.raises(psycopg.OperationalError):
+        await driver.execute_query("SELECT 1")
+
+    assert db_pool._is_valid is False


### PR DESCRIPTION
## Problem

Fixes #98 ("Misshandling of Postgres Pools").

Two defects in `DbConnPool`/`SqlDriver` combine to produce the symptoms reported there — ever-incrementing `pool-N` names, `the pool 'pool-N' is closed` errors on in-flight requests, and memory growth proportional to usage:

1. **Every exception poisoned the shared pool.** `SqlDriver.execute_query` set `_is_valid = False` on *any* error, including query-level ones (bad SQL, undefined tables, statement timeouts). The next call then tore down and rebuilt the pool — so each malformed query churned one pool, which is where the incrementing `pool-N` names come from.
2. **Pool (re)creation raced.** `DbConnPool.pool_connect` had no synchronization: concurrent callers that both observed an invalid pool each built an `AsyncConnectionPool` and assigned it to `self.pool`. Every overwritten pool was left open forever — leaking its connections and background worker tasks — and callers still holding a pool that a later winner closed failed with `the pool 'pool-N' is closed`.

We run this server 24/7 (streamable-http transport, restricted mode) and observed the leak as steady ~6 MiB/day RSS growth that only reset on pod restart.

## Fix

- Only connection-level errors (`OperationalError` / `InterfaceError`, excluding `QueryCanceled`, which just means a statement timed out) invalidate the pool. Query-level errors leave it untouched.
- Pool (re)creation is serialized with an `asyncio.Lock`, with the validity re-checked under the lock, so concurrent reconnects share one pool.
- The pool is created with `check=AsyncConnectionPool.check_connection`, so connections broken while idle (server restart, network blip) are discarded on checkout instead of surfacing as query errors. This should also help with the reconnect complaint in #136.

## Tests

- `test_concurrent_pool_connect_creates_single_pool` — 10 concurrent `pool_connect` calls create exactly one `AsyncConnectionPool` (fails on main: 10 pools, 9 leaked).
- `test_query_error_does_not_invalidate_pool` / `test_statement_timeout_does_not_invalidate_pool` — query-level errors keep the pool valid (fail on main).
- `test_operational_error_invalidates_pool` — connection-level errors still mark the pool for rebuild (guards against over-correcting; passes on main and on this branch).

Note: the new tests wire async context managers via mock's native `__aenter__` support rather than the existing `AsyncContextManagerMock` helper — on current Python, mock's per-instance magic-method machinery shadows that helper's `__aenter__`, so it returns a fresh `AsyncMock` instead of the wired object (existing tests don't notice because they stub the methods under test).

`pytest tests/unit` passes: 195 passed, 1 xfailed. `ruff check`, `ruff format --check`, and `pyright` are clean on the touched files.

🤖 Help provided by [Claude Code](https://claude.com/claude-code)