### PR TITLE
fix: allow EXPLAIN ANALYZE in restricted mode

### DIFF
--- a/src/postgres_mcp/sql/safe_sql.py
+++ b/src/postgres_mcp/sql/safe_sql.py
@@ -906,12 +906,6 @@ class SafeSqlDriver(SqlDriver):
         if isinstance(node, SelectStmt) and getattr(node, "lockingClause", None):
             raise ValueError("Locking clause on select is prohibited")
 
-        # Reject EXPLAIN ANALYZE statements
-        if isinstance(node, ExplainStmt):
-            for option in node.options or []:
-                if isinstance(option, DefElem) and option.defname == "analyze":
-                    raise ValueError("EXPLAIN ANALYZE is not supported")
-
         # Reject CREATE EXTENSION statements
         if isinstance(node, CreateExtensionStmt):
             if node.extname not in self.ALLOWED_EXTENSIONS:

--- a/tests/unit/sql/test_safe_sql.py
+++ b/tests/unit/sql/test_safe_sql.py
@@ -199,28 +199,32 @@ async def test_select_with_commit(safe_driver):
         await safe_driver.execute_query(query)
 
 
+@pytest.mark.parametrize("options", ["FORMAT JSON", "FORMAT JSON, ANALYZE", "ANALYZE, BUFFERS"])
+@pytest.mark.parametrize(
+    "select_query",
+    [
+        "SELECT 1",
+        """SELECT users.name, orders.order_date
+        FROM users
+        JOIN orders ON users.id = orders.user_id
+        WHERE orders.status = 'pending'""",
+    ],
+)
 @pytest.mark.asyncio
-async def test_explain_plan(safe_driver, mock_sql_driver):
-    """Test that EXPLAIN (without ANALYZE) works with bind variables"""
-    query = """
-    EXPLAIN (FORMAT JSON)
-    SELECT id, name
-    FROM users
-    WHERE age > $1 AND status = $2
-    """
+async def test_explain_select(safe_driver, mock_sql_driver, options, select_query):
+    """Test estimated and analyzed plans for read-only queries."""
+    query = f"EXPLAIN ({options}) {select_query}"
+
     await safe_driver.execute_query(query)
+
     mock_sql_driver.execute_query.assert_awaited_once_with("/* crystaldba */ " + query, params=None, force_readonly=True)
 
 
 @pytest.mark.asyncio
-async def test_explain_analyze_blocked(safe_driver):
-    """Test that EXPLAIN ANALYZE is blocked"""
-    query = """
-    EXPLAIN ANALYZE
-    SELECT id, name FROM users
-    """
+async def test_explain_analyze_update_blocked(safe_driver):
+    """Test that ANALYZE does not bypass read-only statement validation."""
     with pytest.raises(ValueError, match="Error validating query"):
-        await safe_driver.execute_query(query)
+        await safe_driver.execute_query("EXPLAIN ANALYZE UPDATE users SET active = false")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Allow restricted-mode `EXPLAIN ANALYZE` for statements that already pass recursive safe-SQL validation. `explain_query(analyze=True)` generates `EXPLAIN (FORMAT JSON, ANALYZE)`, but the validator previously rejected every analyzed plan before PostgreSQL execution.

The underlying query remains recursively validated, and restricted mode still executes it in a read-only transaction. Wrapped write statements remain blocked.

## Tests

- Added estimated and analyzed EXPLAIN coverage for `SELECT 1` and a joined SELECT
- Added direct `EXPLAIN (ANALYZE, BUFFERS)` coverage
- Kept regression coverage proving `EXPLAIN ANALYZE UPDATE` is rejected
- `uv run pytest tests/unit --ignore=tests/unit/explain/test_explain_plan_real_db.py` (175 passed, 1 xfailed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- Verified both `explain_query(analyze=True)` and direct `execute_sql` with `SELECT 1` against a PostgreSQL staging database in restricted mode