### PR TITLE
fix: Block dangerous functions in FROM clause (RangeFunction allowlist bypass) #178

### DIFF
--- a/src/postgres_mcp/sql/safe_sql.py
+++ b/src/postgres_mcp/sql/safe_sql.py
@@ -934,12 +934,20 @@ class SafeSqlDriver(SqlDriver):
                 for item in attr:
                     if isinstance(item, Node):
                         self._validate_node(item)
+                    elif isinstance(item, tuple):
+                        for inner in item:
+                            if isinstance(inner, Node):
+                                self._validate_node(inner)
 
             # Handle tuples of nodes
             elif isinstance(attr, tuple):
                 for item in attr:
                     if isinstance(item, Node):
                         self._validate_node(item)
+                    elif isinstance(item, tuple):
+                        for inner in item:
+                            if isinstance(inner, Node):
+                                self._validate_node(inner)
 
             # Handle single nodes
             elif isinstance(attr, Node):

--- a/tests/unit/sql/test_safe_sql.py
+++ b/tests/unit/sql/test_safe_sql.py
@@ -758,3 +758,25 @@ async def test_query_with_whitespace(safe_driver, mock_sql_driver):
     """
     await safe_driver.execute_query(query)
     mock_sql_driver.execute_query.assert_awaited_once_with("/* crystaldba */ " + query, params=None, force_readonly=True)
+
+
+@pytest.mark.asyncio
+async def test_from_clause_dangerous_function_blocked(safe_driver):
+    """Test that dangerous functions in FROM clause are blocked (CVE: RangeFunction bypass)"""
+    queries = [
+        "SELECT * FROM pg_read_file('/etc/passwd') AS t",
+        "SELECT * FROM pg_ls_dir('/etc') AS t",
+        "SELECT * FROM pg_read_binary_file('/etc/passwd') AS t",
+        "SELECT * FROM pg_stat_file('/etc/passwd') AS t",
+    ]
+    for query in queries:
+        with pytest.raises(ValueError, match="Error validating query"):
+            await safe_driver.execute_query(query)
+
+
+@pytest.mark.asyncio
+async def test_from_clause_allowed_function_permitted(safe_driver, mock_sql_driver):
+    """Test that allowed functions in FROM clause still work after RangeFunction fix"""
+    query = "SELECT * FROM unnest(ARRAY[1,2,3]) AS t"
+    await safe_driver.execute_query(query)
+    mock_sql_driver.execute_query.assert_awaited_once_with("/* crystaldba */ " + query, params=None, force_readonly=True)


### PR DESCRIPTION
## Summary

Fixes a security vulnerability in restricted mode where dangerous server-side functions (e.g. `pg_read_file`, `pg_ls_dir`, `pg_read_binary_file`, `pg_stat_file`) could be invoked from the FROM clause, bypassing the SafeSqlDriver function-name allowlist.

## Vulnerability

The function-name allowlist in `SafeSqlDriver._validate_node` was only checked on `FuncCall` AST nodes. However, when a function is used in the FROM clause, it parses as a `RangeFunction` whose `functions` attribute is a tuple-of-tuples: `((FuncCall, alias),)`. The recursive validator handled tuples by checking if each item is a `Node`, but the inner tuples containing `(FuncCall, alias)` pairs are not `Node` instances, so the `FuncCall` inside was never visited and its name was never checked against `ALLOWED_FUNCTIONS`.

This allowed an attacker (or LLM via prompt injection) to read arbitrary files on the database host:

```sql
-- BLOCKED (target-list FuncCall is checked):
SELECT pg_read_file('/etc/passwd')

-- BYPASSED before fix (RangeFunction FuncCall was not checked):
SELECT * FROM pg_read_file('/etc/passwd') AS t
```

Reported in #178 with a confirmed PoC against PostgreSQL 16.

## Fix

Recurse into nested tuples within list and tuple attributes in `_validate_node`, so that `FuncCall` nodes inside `RangeFunction.functions` are validated against `ALLOWED_FUNCTIONS`.

## Tests

Added two test cases:
- `test_from_clause_dangerous_function_blocked` — verifies `pg_read_file`, `pg_ls_dir`, `pg_read_binary_file`, `pg_stat_file` in FROM clause are blocked
- `test_from_clause_allowed_function_permitted` — verifies `unnest` (an allowed function) in FROM clause still works

All 62 existing tests continue to pass.

## Additional recommendation

Restricted mode should also be run under a least-privilege role without `pg_read_server_files` or superuser privileges, so server-side file functions are unavailable even if a parser gap is found in the future.

Closes #178

_This PR was created by an AI agent (OpenHands) on behalf of @jssmith._