### PR TITLE
fix: Pin mcp[cli]<2.0 to prevent breaking import change #187

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "PostgreSQL Tuning and Analysis Tool"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.25.0",
+    "mcp[cli]>=1.25.0,<2.0",
     "psycopg[binary]>=3.3.2",
     "humanize>=4.15.0",
     "pglast==7.11",


### PR DESCRIPTION
## Summary

Fixes a breaking dependency issue where `uvx postgres-mcp` fails to start because `mcp 2.0.0` removed `mcp.server.fastmcp`.

## Problem

The `pyproject.toml` dependency `mcp[cli]>=1.25.0` is unconstrained on the upper bound. When `mcp 2.0.0` was released, it removed the `mcp.server.fastmcp` module that `postgres-mcp` imports, causing:

```
$ uvx --python 3.13 postgres-mcp
ModuleNotFoundError: No module named mcp.server.fastmcp
```

This affects all users installing via `uvx` or `pip install postgres-mcp`.

## Fix

Pin the dependency to `mcp[cli]>=1.25.0,<2.0` to prevent pulling in the breaking 2.x release until the codebase is updated for the new mcp API.

## Verification

- Confirmed `from mcp.server.fastmcp import FastMCP` works with `mcp==1.29.0` (latest 1.x)
- All 71 unit tests pass

## Workaround for existing users

Until this fix is released, users can pin manually:

```sh
uvx --python 3.13 --with "mcp[cli]==1.29.0" postgres-mcp
```

Closes #187

_This PR was created by an AI agent (OpenHands) on behalf of @jssmith._