### PR TITLE
feat: Add timezone to ALLOWED_FUNCTIONS

### DIFF
--- a/src/postgres_mcp/sql/safe_sql.py
+++ b/src/postgres_mcp/sql/safe_sql.py
@@ -478,6 +478,7 @@ class SafeSqlDriver(SqlDriver):
         "now",
         "statement_timestamp",
         "timeofday",
+        "timezone",
         "transaction_timestamp",
         # Additional Type Conversion
         "cast",

--- a/tests/unit/sql/test_safe_sql.py
+++ b/tests/unit/sql/test_safe_sql.py
@@ -521,6 +521,8 @@ async def test_datetime_functions(safe_driver, mock_sql_driver):
         "SELECT now()",
         "SELECT statement_timestamp()",
         "SELECT timeofday()",
+        "SELECT timezone('UTC', timestamp with time zone '2001-02-16 20:38:40-05')",
+        "SELECT timestamp with time zone '2001-02-16 20:38:40-05' AT TIME ZONE 'America/Denver'",
         "SELECT transaction_timestamp()",
     ]
 


### PR DESCRIPTION
The `timezone` function is documented further down on https://www.postgresql.org/docs/current/functions-datetime.html than "Table 9.33. Date/Time Functions", it's [here](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT):

> The function `timezone(zone, timestamp)` is equivalent to the SQL-conforming construct `timestamp AT TIME ZONE zone`.
>
> The function `timezone(zone, time)` is equivalent to the SQL-conforming construct `time AT TIME ZONE zone`.
>
> The function `timezone(timestamp)` is equivalent to the SQL-conforming construct `timestamp AT LOCAL`.
>
> The function `timezone(time)` is equivalent to the SQL-conforming construct `time AT LOCAL`.

I'm copying the pattern from https://github.com/crystaldba/postgres-mcp/pull/118, happy to make any changes.