### PR TITLE
feat: add --stateless-http flag for streamable HTTP

### DIFF
--- a/src/postgres_mcp/server.py
+++ b/src/postgres_mcp/server.py
@@ -596,6 +596,11 @@ async def main():
         default=8000,
         help="Port for streamable HTTP server (default: 8000)",
     )
+    parser.add_argument(
+        "--stateless-http",
+        action="store_true",
+        help="Serve streamable HTTP statelessly: retain no per-session server state, so sessions clients never DELETE cannot leak memory",
+    )
 
     args = parser.parse_args()
 
@@ -666,6 +671,7 @@ async def main():
     elif args.transport == "streamable-http":
         mcp.settings.host = args.streamable_http_host
         mcp.settings.port = args.streamable_http_port
+        mcp.settings.stateless_http = args.stateless_http
         await mcp.run_streamable_http_async()
 
 

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -127,3 +127,112 @@ async def test_default_transport_is_stdio():
             mock_http.assert_not_called()
     finally:
         sys.argv = original_argv
+
+
+@pytest.mark.asyncio
+async def test_stateless_http_argument_sets_setting():
+    """Test that --stateless-http enables FastMCP's stateless_http setting."""
+    from postgres_mcp.server import main
+    from postgres_mcp.server import mcp
+
+    original_argv = sys.argv
+    try:
+        sys.argv = [
+            "postgres_mcp",
+            "postgresql://user:password@localhost/db",
+            "--transport=streamable-http",
+            "--stateless-http",
+        ]
+
+        with (
+            patch("postgres_mcp.server.db_connection.pool_connect", AsyncMock()),
+            patch("postgres_mcp.server.mcp.run_streamable_http_async", AsyncMock()),
+        ):
+            await main()
+
+            assert mcp.settings.stateless_http is True
+    finally:
+        sys.argv = original_argv
+
+
+@pytest.mark.asyncio
+async def test_stateless_http_defaults_to_stateful():
+    """Test that streamable-http stays stateful when --stateless-http is not passed."""
+    from postgres_mcp.server import main
+    from postgres_mcp.server import mcp
+
+    original_argv = sys.argv
+    try:
+        sys.argv = [
+            "postgres_mcp",
+            "postgresql://user:password@localhost/db",
+            "--transport=streamable-http",
+        ]
+
+        with (
+            patch("postgres_mcp.server.db_connection.pool_connect", AsyncMock()),
+            patch("postgres_mcp.server.mcp.run_streamable_http_async", AsyncMock()),
+        ):
+            await main()
+
+            assert mcp.settings.stateless_http is False
+    finally:
+        sys.argv = original_argv
+
+
+# The two tests below pin the SDK behavior --stateless-http exists for, so an mcp
+# SDK bump that changes stateless streamable-HTTP semantics fails here instead of
+# resurfacing in production as a memory leak: in stateful mode the SDK retains
+# per-session state until the client sends DELETE /mcp, so clients that never do
+# (most MCP connectors) grow the server's memory without bound. They use fresh
+# FastMCP instances rather than postgres_mcp.server's, because a FastMCP instance
+# builds its session manager once and the manager can only run once.
+
+
+def _streamable_http_client(server):
+    """TestClient for the server's streamable-HTTP app.
+
+    The base_url matters: the SDK's DNS-rebinding protection only accepts
+    localhost Host headers by default, and TestClient's default Host
+    (testserver) is rejected with 421.
+    """
+    from starlette.testclient import TestClient
+
+    return TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:8000")
+
+
+def _sessionless_tools_list(client):
+    """POST tools/list with no Mcp-Session-Id header and no prior initialize."""
+    return client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        headers={"Accept": "application/json, text/event-stream"},
+    )
+
+
+def test_stateless_streamable_http_serves_sessionless_requests():
+    """Test that stateless mode serves requests that carry no session."""
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("stateless-contract-test", stateless_http=True)
+    with _streamable_http_client(server) as client:
+        response = _sessionless_tools_list(client)
+
+        assert response.status_code == 200
+
+
+def test_stateful_streamable_http_rejects_sessionless_requests():
+    """Test that stateful mode rejects the same sessionless request.
+
+    Guards the contrast with the stateless test above: if this ever starts
+    passing requests through, the stateless test no longer proves the flag
+    changes behavior.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    server = FastMCP("stateful-contract-test", stateless_http=False)
+    with _streamable_http_client(server) as client:
+        response = _sessionless_tools_list(client)
+
+        assert response.status_code == 400
+        assert "session" in response.text.lower()


### PR DESCRIPTION
## Problem

In stateful streamable-HTTP mode (the default), the MCP SDK's `StreamableHTTPSessionManager` retains each session's server-side state until the client sends `DELETE /mcp`. Many MCP clients — hosted connectors, agent frameworks — create sessions freely and never send that DELETE, so a long-running postgres-mcp server's memory grows without bound.

Concretely, in one production deployment we measured ~720 never-terminated sessions/day at ~110KB retained each — about 77MiB/day of working-set growth (48h of logs showed zero `DELETE /mcp` requests and zero session terminations). Memory never plateaus and is only reclaimed by restarting the server; we currently run a daily restart as a workaround.

## Change

Adds a `--stateless-http` flag that opts the `streamable-http` transport into FastMCP's stateless mode (`stateless_http=True`): the SDK creates a fresh ephemeral transport per request and keeps no session registry, so there is nothing to accumulate. The cost is server-initiated messages and session resumability, which postgres-mcp doesn't use. Default behavior (flag omitted) is unchanged.

## Testing

Four new tests in `tests/unit/test_transport.py`:

- **Flag plumbing** (same patch-`main()` pattern as the existing transport tests): `--stateless-http` sets `mcp.settings.stateless_http = True`; omitting it leaves the stateful default.
- **Session contract**: a stateless server serves a `tools/list` POST that carries no session ID and no prior initialize (HTTP 200), while a stateful server rejects the identical request (HTTP 400, "Missing session ID"). These pin the SDK behavior the flag relies on, so a future SDK bump that changes stateless semantics fails in CI instead of silently reintroducing unbounded session growth. They use fresh `FastMCP` instances (a FastMCP builds its session manager once, and a manager can only run once) and a `127.0.0.1` base URL (the SDK's DNS-rebinding protection rejects the test client's default `testserver` Host with 421).

`uv run pytest tests/unit` passes, `ruff check` / `ruff format --check` clean. Also smoke-tested live: with the flag, a sessionless `tools/list` returns the full tool list and no per-session transports are logged, while the same request against a stateful server is rejected with "Missing session ID".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
